### PR TITLE
2 update formatters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,49 +22,56 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    home-manager,
-    ...
-  } @ inputs: let
-    inherit (self) outputs;
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+      ...
+    }@inputs:
+    let
+      inherit (self) outputs;
 
-    system = "x86_64-linux";
+      system = "x86_64-linux";
 
-    pkgsForSystem = system: nixpkgsSource:
-      import nixpkgsSource {
-        overlays = [
-          #NOTE: add your custom overlays here
-        ];
-        inherit system;
-      };
+      # pkgs = nixpkgs.legacyPackages.${system};
 
-    HomeConfiguration = args:
-      home-manager.lib.homeManagerConfiguration {
-        modules = [
-          (import ./hosts)
-          (import ./modules)
-        ];
-        extraSpecialArgs =
-          {
+      pkgsForSystem =
+        system: nixpkgsSource:
+        import nixpkgsSource {
+          overlays = [
+            #NOTE: add your custom overlays here
+          ];
+          inherit system;
+        };
+
+      HomeConfiguration =
+        args:
+        home-manager.lib.homeManagerConfiguration {
+          modules = [
+            (import ./hosts)
+            (import ./modules)
+          ];
+          extraSpecialArgs = {
             inherit (args) nixpkgs;
-          }
-          // args.extraSpecialArgs;
-        pkgs = pkgsForSystem (args.system or system) nixpkgs;
-      };
-  in {
-    homeConfigurations = {
-      "luna.shorty" = HomeConfiguration {
-        extraSpecialArgs = {
-          inherit inputs outputs;
-          hostname = "luna";
-          username = "shorty";
-          fullName = "Jordy Schreuders";
-          email = "3071062+99linesofcode@users.noreply.github.com";
-          role = "workstation";
+          } // args.extraSpecialArgs;
+          pkgs = pkgsForSystem (args.system or system) nixpkgs;
+        };
+    in
+    {
+      formatter.${system} = nixpkgs.legacyPackages.${system}.nixfmt-rfc-style;
+
+      homeConfigurations = {
+        "luna.shorty" = HomeConfiguration {
+          extraSpecialArgs = {
+            inherit inputs outputs;
+            hostname = "luna";
+            username = "shorty";
+            fullName = "Jordy Schreuders";
+            email = "3071062+99linesofcode@users.noreply.github.com";
+            role = "workstation";
+          };
         };
       };
     };
-  };
 }

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -2,17 +2,16 @@
   pkgs,
   specialArgs,
   ...
-}: let
+}:
+let
   inherit (pkgs.stdenv) isDarwin;
   inherit (specialArgs) hostname username;
   if-exists = f: builtins.pathExists f;
   existing-imports = imports: builtins.filter if-exists imports;
 
-  homeDir =
-    if isDarwin
-    then "/Users/"
-    else "/home/";
-in {
+  homeDir = if isDarwin then "/Users/" else "/home/";
+in
+{
   imports =
     [
       ./shared

--- a/hosts/luna/default.nix
+++ b/hosts/luna/default.nix
@@ -1,8 +1,10 @@
-{specialArgs, ...}: let
+{ specialArgs, ... }:
+let
   inherit (specialArgs) role username;
   if-exists = f: builtins.pathExists f;
   existing-imports = imports: builtins.filter if-exists imports;
-in {
+in
+{
   imports =
     [
     ]

--- a/hosts/luna/users/shorty/default.nix
+++ b/hosts/luna/users/shorty/default.nix
@@ -3,7 +3,8 @@
   pkgs,
   ...
 }:
-with lib; {
+with lib;
+{
   home.dunst.enable = true;
   home.firefox.enable = true;
   home.git.enable = true;
@@ -23,23 +24,24 @@ with lib; {
 
   home = {
     packages = with pkgs; [
-      android-tools
       beeper
       bitwarden
       bitwarden-cli
       bws
       electron
-      (freecad.override {withWayland = true;})
-      # figlet
-      # gcc
-      lazydocker
+      (freecad.override { withWayland = true; })
       nix-prefetch-git
       obsidian
       polychromatic
       rustdesk
       scrcpy
-      skypeforlinux
       webcord
+      # development tools
+      android-tools
+      act # run GitHub Actions locally
+      # figlet
+      # gcc
+      lazydocker
       # debugging and reverse engineering
       wireshark
       gdb

--- a/hosts/shared/default.nix
+++ b/hosts/shared/default.nix
@@ -1,8 +1,10 @@
-{specialArgs, ...}: let
+{ specialArgs, ... }:
+let
   inherit (specialArgs) role username;
   if-exists = f: builtins.pathExists f;
   existing-imports = imports: builtins.filter if-exists imports;
-in {
+in
+{
   imports =
     [
       ./nix.nix

--- a/hosts/shared/locale.nix
+++ b/hosts/shared/locale.nix
@@ -2,30 +2,32 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   locale = "en_US.UTF-8";
 in
-  with lib; {
-    home = {
-      packages = with pkgs; [
-        hunspell
-        hunspellDicts.en_GB-ise
-        hunspellDicts.en_US
-        hunspellDicts.nl_NL
-      ];
-      language = {
-        address = mkDefault locale;
-        base = mkDefault locale;
-        collate = mkDefault locale;
-        ctype = mkDefault locale;
-        measurement = mkDefault locale;
-        messages = mkDefault locale;
-        monetary = mkDefault locale;
-        name = mkDefault locale;
-        numeric = mkDefault locale;
-        paper = mkDefault locale;
-        telephone = mkDefault locale;
-        time = mkDefault locale;
-      };
+with lib;
+{
+  home = {
+    packages = with pkgs; [
+      hunspell
+      hunspellDicts.en_GB-ise
+      hunspellDicts.en_US
+      hunspellDicts.nl_NL
+    ];
+    language = {
+      address = mkDefault locale;
+      base = mkDefault locale;
+      collate = mkDefault locale;
+      ctype = mkDefault locale;
+      measurement = mkDefault locale;
+      messages = mkDefault locale;
+      monetary = mkDefault locale;
+      name = mkDefault locale;
+      numeric = mkDefault locale;
+      paper = mkDefault locale;
+      telephone = mkDefault locale;
+      time = mkDefault locale;
     };
-  }
+  };
+}

--- a/hosts/shared/nix.nix
+++ b/hosts/shared/nix.nix
@@ -3,7 +3,8 @@
   pkgs,
   ...
 }:
-with lib; {
+with lib;
+{
   nixpkgs = {
     config = {
       allowUnfree = mkDefault true;
@@ -15,7 +16,10 @@ with lib; {
     package = pkgs.nix;
     settings = {
       auto-optimise-store = mkDefault true;
-      experimental-features = ["nix-command" "flakes"];
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
       use-xdg-base-directories = mkDefault true;
     };
   };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   imports = [
     ./dunst.nix
     ./firefox.nix

--- a/modules/dunst.nix
+++ b/modules/dunst.nix
@@ -3,21 +3,23 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.home.dunst;
 in
-  with lib; {
-    options = {
-      home.dunst.enable = mkEnableOption "dunst notifications manager";
-    };
+with lib;
+{
+  options = {
+    home.dunst.enable = mkEnableOption "dunst notifications manager";
+  };
 
-    config = mkIf cfg.enable {
-      home.packages = with pkgs; [
-        libnotify
-      ];
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      libnotify
+    ];
 
-      services.dunst = {
-        enable = true;
-      };
+    services.dunst = {
+      enable = true;
     };
-  }
+  };
+}

--- a/modules/firefox.nix
+++ b/modules/firefox.nix
@@ -4,82 +4,87 @@
   pkgs,
   specialArgs,
   ...
-}: let
+}:
+let
   inherit (specialArgs) username;
   cfg = config.home.firefox;
 in
-  with lib; {
-    options = {
-      home.firefox.enable = mkEnableOption "firefox";
-    };
+with lib;
+{
+  options = {
+    home.firefox.enable = mkEnableOption "firefox";
+  };
 
-    config = mkIf cfg.enable {
-      programs.firefox = {
-        enable = true;
-        package = pkgs.wrapFirefox (pkgs.firefox-unwrapped.override {
-          pipewireSupport = true;
-        }) {};
-        profiles = {
-          ${username} = {
-            search = {
-              force = true;
-              default = "Google";
-              privateDefault = "DuckDuckGo";
-              order = ["Google" "DuckDuckGo"];
-              engines = {
-                "Bing".metaData.hidden = true;
-                "DuckDuckGo".metaData.alias = "@d";
-                "Google".metaData.alias = "@g";
-                "Wikipedia (en)".metaData.alias = "@w";
+  config = mkIf cfg.enable {
+    programs.firefox = {
+      enable = true;
+      package = pkgs.wrapFirefox (pkgs.firefox-unwrapped.override {
+        pipewireSupport = true;
+      }) { };
+      profiles = {
+        ${username} = {
+          search = {
+            force = true;
+            default = "Google";
+            privateDefault = "DuckDuckGo";
+            order = [
+              "Google"
+              "DuckDuckGo"
+            ];
+            engines = {
+              "Bing".metaData.hidden = true;
+              "DuckDuckGo".metaData.alias = "@d";
+              "Google".metaData.alias = "@g";
+              "Wikipedia (en)".metaData.alias = "@w";
 
-                "Github" = {
-                  urls = [{template = "https://github.com/search?q={searchTerms}";}];
-                  iconUpdateURL = "https://github.githubassets.com/favicons/favicon.svg";
-                  definedAliases = ["@gh"];
-                };
+              "Github" = {
+                urls = [ { template = "https://github.com/search?q={searchTerms}"; } ];
+                iconUpdateURL = "https://github.githubassets.com/favicons/favicon.svg";
+                definedAliases = [ "@gh" ];
+              };
 
-                "Reddit" = {
-                  urls = [{template = "https://reddit.com/search?q={searchTerms}";}];
-                  iconUpdateURL = "https://www.redditstatic.com/shreddit/assets/favicon/192x192.png";
-                  definedAliases = ["@r"];
-                };
+              "Reddit" = {
+                urls = [ { template = "https://reddit.com/search?q={searchTerms}"; } ];
+                iconUpdateURL = "https://www.redditstatic.com/shreddit/assets/favicon/192x192.png";
+                definedAliases = [ "@r" ];
+              };
 
-                "MyNixOS" = {
-                  urls = [{template = "https://mynixos.com/search?q={searchTerms}";}];
-                  icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
-                  definedAliases = ["@n"];
-                };
+              "MyNixOS" = {
+                urls = [ { template = "https://mynixos.com/search?q={searchTerms}"; } ];
+                icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+                definedAliases = [ "@n" ];
+              };
 
-                "NixOS Wiki" = {
-                  urls = [{template = "https://nixos.wiki/index.php?search={searchTerms}";}];
-                  iconUpdateURL = "https://wiki.nixos.org/favicon.png";
-                  definedAliases = ["@nw"];
-                };
+              "NixOS Wiki" = {
+                urls = [ { template = "https://nixos.wiki/index.php?search={searchTerms}"; } ];
+                iconUpdateURL = "https://wiki.nixos.org/favicon.png";
+                definedAliases = [ "@nw" ];
+              };
 
-                "ProtonDB" = {
-                  urls = [{template = "https://protondb.com/search?q={searchTerms}";}];
-                  iconUpdateURL = "https://protondb.com/sites/protondb/images/favicon-32x32.png";
-                  definedAliases = ["@p"];
-                };
+              "ProtonDB" = {
+                urls = [ { template = "https://protondb.com/search?q={searchTerms}"; } ];
+                iconUpdateURL = "https://protondb.com/sites/protondb/images/favicon-32x32.png";
+                definedAliases = [ "@p" ];
+              };
 
-                "YouTube" = {
-                  urls = [{template = "https://youtube.com/results?search_query={searchTerms}";}];
-                  iconUpdateURL = "https://youtube.com/img/favicon_144.png";
-                  definedAliases = ["@yt"];
-                };
+              "YouTube" = {
+                urls = [ { template = "https://youtube.com/results?search_query={searchTerms}"; } ];
+                iconUpdateURL = "https://youtube.com/img/favicon_144.png";
+                definedAliases = [ "@yt" ];
+              };
 
-                "YouTube Music" = {
-                  urls = [{template = "https://music.youtube.com/search?q={searchTerms}";}];
-                  iconUpdateURL = "https://music.youtube.com/img/favicon_144.png";
-                  definedAliases = ["@ytm"];
-                };
+              "YouTube Music" = {
+                urls = [ { template = "https://music.youtube.com/search?q={searchTerms}"; } ];
+                iconUpdateURL = "https://music.youtube.com/img/favicon_144.png";
+                definedAliases = [ "@ytm" ];
               };
             };
-            settings = {
-              "widget.use-xdg-desktop-portal.file-picker" = 1;
-            };
+          };
+          settings = {
+            "widget.use-xdg-desktop-portal.file-picker" = 1;
           };
         };
       };
     };
-  }
+  };
+}

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -3,62 +3,64 @@
   lib,
   specialArgs,
   ...
-}: let
+}:
+let
   inherit (specialArgs) fullName email;
   cfg = config.home.git;
 in
-  with lib; {
-    options = {
-      home.git.enable = mkEnableOption "git";
-    };
+with lib;
+{
+  options = {
+    home.git.enable = mkEnableOption "git";
+  };
 
-    config = mkIf cfg.enable {
-      programs = {
-        git = {
-          enable = true;
-          aliases = {
-            fix = "commit --fixup";
-            pufowile = "push --force-with-lease";
-            sl = "log --oneline --decorate --graph";
-            sla = "sl --all";
-          };
-          extraConfig = {
-            branch.autoSetupRebase = "always";
-            commit.gpgSign = true;
-            core = {
-              autocrlf = false;
-              editor = "nvim";
-              eol = "lf";
-              excludesFile = "../dotfiles/git/.gitignore_global";
-            };
-            diff.submodule = "log";
-            fetch.prune = true;
-            gpg.format = "ssh";
-            init.defaultBranch = "main";
-            pull = {
-              default = "current";
-              rebase = true;
-            };
-            push = {
-              default = "current";
-              recurseSubmodules = "on-demand";
-            };
-            rebase.autoSquash = true;
-            rerere.enabled = true; # REuse REcorded REsolution
-            status.submoduleSummary = true;
-            tag.gpgSign = true;
-          };
-          userName = fullName;
-          userEmail = email;
-          signing.key = "${config.home.homeDirectory}/.ssh/id_ed25519.pub";
+  config = mkIf cfg.enable {
+    programs = {
+      git = {
+        enable = true;
+        aliases = {
+          fix = "commit --fixup";
+          pufowile = "push --force-with-lease";
+          sl = "log --oneline --decorate --graph";
+          sla = "sl --all";
         };
-        lazygit = {
-          enable = true;
-          settings = {
-            quitOnTopLevelReturn = true; # exit Lazygit when the user presses escape in a context where there is nothing to cancel/close
-            git.overrideGpg = true; # do not spawn a separate process when using GPG
+        extraConfig = {
+          branch.autoSetupRebase = "always";
+          commit.gpgSign = true;
+          core = {
+            autocrlf = false;
+            editor = "nvim";
+            eol = "lf";
+            excludesFile = "../dotfiles/git/.gitignore_global";
           };
+          diff.submodule = "log";
+          fetch.prune = true;
+          gpg.format = "ssh";
+          init.defaultBranch = "main";
+          pull = {
+            default = "current";
+            rebase = true;
+          };
+          push = {
+            default = "current";
+            recurseSubmodules = "on-demand";
+          };
+          rebase.autoSquash = true;
+          rerere.enabled = true; # REuse REcorded REsolution
+          status.submoduleSummary = true;
+          tag.gpgSign = true;
+        };
+        userName = fullName;
+        userEmail = email;
+        signing.key = "${config.home.homeDirectory}/.ssh/id_ed25519.pub";
+      };
+      lazygit = {
+        enable = true;
+        settings = {
+          quitOnTopLevelReturn = true; # exit Lazygit when the user presses escape in a context where there is nothing to cancel/close
+          git.overrideGpg = true; # do not spawn a separate process when using GPG
         };
       };
     };
-  }
+  };
+}

--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -3,274 +3,276 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.home.hyprland;
 in
-  with lib; {
-    options = {
-      home.hyprland.enable = mkEnableOption "hyprland";
+with lib;
+{
+  options = {
+    home.hyprland.enable = mkEnableOption "hyprland";
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile = {
+      "hypr/state.conf" = {
+        source = ../dotfiles/hypr/state.conf;
+        force = true;
+      };
+      "hypr/scripts/bluetooth-toggle.sh".source = ../dotfiles/hypr/scripts/bluetooth-toggle.sh;
+      "hypr/scripts/display-toggle.sh".source = ../dotfiles/hypr/scripts/display-toggle.sh;
     };
 
-    config = mkIf cfg.enable {
-      xdg.configFile = {
-        "hypr/state.conf" = {
-          source = ../dotfiles/hypr/state.conf;
-          force = true;
-        };
-        "hypr/scripts/bluetooth-toggle.sh".source = ../dotfiles/hypr/scripts/bluetooth-toggle.sh;
-        "hypr/scripts/display-toggle.sh".source = ../dotfiles/hypr/scripts/display-toggle.sh;
+    home = {
+      sessionVariables = {
+        NIXOS_OZONE_WL = "1";
+        # GSK_RENDERER = "gl";
       };
+      packages = with pkgs; [
+        brightnessctl
+        grim
+        hypridle
+        hyprpaper
+        hyprpicker
+        hyprshade
+        nwg-dock-hyprland
+        pipewire
+        polkit
+        polkit_gnome
+        slurp
+        swappy
+        waypaper
+        wl-clipboard
+        wireplumber
+        xdg-utils
+        # GUI components
+        bluez # bluetooth
+        bluez-tools # bluetooth
+        iwgtk
+        pavucontrol
+        qalculate-gtk
+      ];
+    };
 
-      home = {
-        sessionVariables = {
-          NIXOS_OZONE_WL = "1";
-          # GSK_RENDERER = "gl";
-        };
-        packages = with pkgs; [
-          brightnessctl
-          grim
-          hypridle
-          hyprpaper
-          hyprpicker
-          hyprshade
-          nwg-dock-hyprland
-          pipewire
-          polkit
-          polkit_gnome
-          slurp
-          swappy
-          waypaper
-          wl-clipboard
-          wireplumber
-          xdg-utils
-          # GUI components
-          bluez # bluetooth
-          bluez-tools # bluetooth
-          iwgtk
-          pavucontrol
-          qalculate-gtk
+    services = {
+      blueman-applet.enable = true; # bluetooth
+      cliphist.enable = true;
+      hyprpaper.enable = true;
+      mpris-proxy.enable = true; # bluetooth
+      udiskie.enable = true;
+    };
+
+    programs = {
+      hyprlock.enable = true;
+      # sddm.enable = true;
+      wlogout.enable = true;
+    };
+
+    wayland.windowManager.hyprland = {
+      enable = true;
+      xwayland.enable = true;
+      systemd.enable = true;
+      settings = {
+        env = [
+          # Theming
+          "CLUTTER_BACKEND,wayland"
+          "GDK_BACKEND,wayland"
+          "GDK_SCALE,2"
+          "SDL_VIDEODRIVER,wayland"
+          "QT_AUTO_SCREEN_SCALE_FACTOR,2"
+          "QT_QPA_PLATFORM,wayland;xcb"
+          "QT_QPA_PLATFORMTHEME,qt6ct"
+          "QT_WAYLAND_DISABLE_WINDOWDECORATION,1"
+
+          # XDG
+          "XDG_CURRENT_DESKTOP,Hyprland"
+          "XDG_SESSION_TYPE,wayland"
+          "XDG_SESSION_DESKTOP,Hyprland"
+
+          # Nvidia
+          "LIBVA_DRIVER_NAME,nvidia"
+          "GBM_BACKEND,nvidia-drm"
+          "__GLX_VENDOR_LIBRARY_NAME,nvidia"
+
+          # Firefox
+          "NVD_BACKEND,direct"
+          "MOZ_DISABLE_RDD_SANDBOX,1"
+          "MOZ_ENABLE_WAYLAND,1"
+          "EGL_PLATFORM,wayland"
         ];
-      };
 
-      services = {
-        blueman-applet.enable = true; # bluetooth
-        cliphist.enable = true;
-        hyprpaper.enable = true;
-        mpris-proxy.enable = true; # bluetooth
-        udiskie.enable = true;
-      };
+        # TODO: extract to each individual module
+        exec-once = [
+          "waybar"
+          "swww-daemon"
+          "swayidle -w timeout 10 'if pgrep -x swaylock; then hyprctl dispatch dpms off; fi' resume 'hyprctl dispatch dpms on'"
+          "swayidle -w timeout 300 'swaylock -f -C ~/.config/swaylock/config' timeout 330 'hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on'"
+          "udiskie &"
+          "/usr/bin/dunst"
+          "/usr/lib/polkit-kde-authentication-agent-1"
+          "/usr/lib/pam_kwallet_init"
+          "wl-paste -w cliphist store" # TODO: switch to clipse or stick with rofi and cliphist?
+          "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP"
+        ];
 
-      programs = {
-        hyprlock.enable = true;
-        # sddm.enable = true;
-        wlogout.enable = true;
-      };
+        monitor = [
+          "eDP-1,highres,0x0,2.0"
+        ];
 
-      wayland.windowManager.hyprland = {
-        enable = true;
-        xwayland.enable = true;
-        systemd.enable = true;
-        settings = {
-          env = [
-            # Theming
-            "CLUTTER_BACKEND,wayland"
-            "GDK_BACKEND,wayland"
-            "GDK_SCALE,2"
-            "SDL_VIDEODRIVER,wayland"
-            "QT_AUTO_SCREEN_SCALE_FACTOR,2"
-            "QT_QPA_PLATFORM,wayland;xcb"
-            "QT_QPA_PLATFORMTHEME,qt6ct"
-            "QT_WAYLAND_DISABLE_WINDOWDECORATION,1"
+        workspace = [
+          "eDP-1,1"
+        ];
 
-            # XDG
-            "XDG_CURRENT_DESKTOP,Hyprland"
-            "XDG_SESSION_TYPE,wayland"
-            "XDG_SESSION_DESKTOP,Hyprland"
+        cursor.no_hardware_cursors = true;
 
-            # Nvidia
-            "LIBVA_DRIVER_NAME,nvidia"
-            "GBM_BACKEND,nvidia-drm"
-            "__GLX_VENDOR_LIBRARY_NAME,nvidia"
-
-            # Firefox
-            "NVD_BACKEND,direct"
-            "MOZ_DISABLE_RDD_SANDBOX,1"
-            "MOZ_ENABLE_WAYLAND,1"
-            "EGL_PLATFORM,wayland"
-          ];
-
-          # TODO: extract to each individual module
-          exec-once = [
-            "waybar"
-            "swww-daemon"
-            "swayidle -w timeout 10 'if pgrep -x swaylock; then hyprctl dispatch dpms off; fi' resume 'hyprctl dispatch dpms on'"
-            "swayidle -w timeout 300 'swaylock -f -C ~/.config/swaylock/config' timeout 330 'hyprctl dispatch dpms off' resume 'hyprctl dispatch dpms on'"
-            "udiskie &"
-            "/usr/bin/dunst"
-            "/usr/lib/polkit-kde-authentication-agent-1"
-            "/usr/lib/pam_kwallet_init"
-            "wl-paste -w cliphist store" # TODO: switch to clipse or stick with rofi and cliphist?
-            "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP"
-          ];
-
-          monitor = [
-            "eDP-1,highres,0x0,2.0"
-          ];
-
-          workspace = [
-            "eDP-1,1"
-          ];
-
-          cursor.no_hardware_cursors = true;
-
-          decoration = {
-            rounding = 3;
-            blur = {
-              size = 3;
-              xray = true;
-            };
-            shadow = {
-              range = 30;
-              color = "0x66000000";
-            };
+        decoration = {
+          rounding = 3;
+          blur = {
+            size = 3;
+            xray = true;
           };
-          dwindle = {
-            pseudotile = true;
-            preserve_split = true;
+          shadow = {
+            range = 30;
+            color = "0x66000000";
           };
-
-          general = {
-            gaps_out = 10;
-          };
-          gestures.workspace_swipe = true;
-
-          input = {
-            kb_options = "caps:swapescape";
-            sensitivity = 0.2;
-            touchpad.natural_scroll = true;
-          };
-
-          master.new_status = "master";
-          misc = {
-            disable_hyprland_logo = true;
-            disable_splash_rendering = true;
-            enable_swallow = true;
-          };
-
-          xwayland.force_zero_scaling = true;
-
-          bind = [
-            # Passthrough
-            "SUPER_ALT_CTRL, R, pass, ^(com\.obsproject\.Studio)$"
-            "SUPER_ALT_CTRL, S, pass, ^(com\.obsproject\.Studio)$"
-
-            # Hotkeys
-            "SUPER, Q, exec, wlogout"
-            "SUPER, Return, exec, alacritty"
-            "SUPER, Space, exec, rofi -show-icons -show drun -l 10"
-            "SUPER, E, exec, alacritty -e 'yazi'"
-            "SUPER, C, exec, qalculate-gtk"
-            "SUPER, D, exec, hyprpicker -na"
-            "SUPER, S, exec, grim -g \"$(slurp)\" - | swappy -f - | wl-copy"
-            "SUPER, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy"
-
-            "SUPER_ALT, M, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
-            "SUPER_ALT, B, exec, ~/.config/hypr/scripts/bluetooth-toggle.sh"
-
-            # Fn keys
-            ", XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
-            ", XF86AudioPrev, exec, playerctl previous"
-            ", XF86AudioPlay, exec, playerctl play-pause"
-            ", XF86AudioNext, exec, playerctl next"
-
-            # Manipulate windows
-            "SUPER, W, killactive"
-            "SUPER, F, fullscreen"
-            "SUPER_CTRL, F, togglefloating"
-            "SUPER_CTRL, S, togglesplit"
-
-            # Focus window
-            "SUPER, H, movefocus, l"
-            "SUPER, H, alterzorder, top"
-            "SUPER, L, movefocus, r"
-            "SUPER, L, alterzorder, top"
-            "SUPER, K, movefocus, u"
-            "SUPER, K, alterzorder, top"
-            "SUPER, J, movefocus, d"
-            "SUPER, J, alterzorder, top"
-
-            # Move window
-            "SUPER_CTRL, H, movewindow, l"
-            "SUPER_CTRL, L, movewindow, r"
-            "SUPER_CTRL, K, movewindow, u"
-            "SUPER_CTRL, J, movewindow, d"
-
-            # Cycle through windows
-            "SUPER, Tab, cyclenext"
-            "SUPER, Tab, alterzorder, top"
-            "SUPER_SHIFT, Tab, cyclenext, prev"
-            "SUPER_SHIFT, Tab, alterzorder, top"
-
-            # Switch workspace
-            "SUPER, 1, workspace, 1"
-            "SUPER, 2, workspace, 2"
-            "SUPER, 3, workspace, 3"
-            "SUPER, 4, workspace, 4"
-            "SUPER, 5, workspace, 5"
-            "SUPER, 6, workspace, 6"
-
-            # Move window to workspace
-            "SUPER_SHIFT, 1, movetoworkspace, 1"
-            "SUPER_SHIFT, 2, movetoworkspace, 2"
-            "SUPER_SHIFT, 3, movetoworkspace, 3"
-            "SUPER_SHIFT, 4, movetoworkspace, 4"
-            "SUPER_SHIFT, 5, movetoworkspace, 5"
-            "SUPER_SHIFT, 6, movetoworkspace, 6"
-
-            # Scroll through workspaces
-            "SUPER_SHIFT, mouse_down, workspace, e+1"
-            "SUPER_SHIFT, mouse_up, workspace, e-1"
-          ];
-
-          binde = [
-            # Fn keys
-            ", XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.25 @DEFAULT_AUDIO_SINK@ 5%+"
-            ", XF86AudioLowerVolume, exec, wpctl set-volume -l 1.25 @DEFAULT_AUDIO_SINK@ 5%-"
-            "SUPER, P, exec, ~/.config/hypr/scripts/display-toggle.sh"
-            ", XF86MonBrightnessDown, exec, brightnessctl s 10%-"
-            ", XF86MonBrightnessUp, exec, brightnessctl s 10%+"
-            ", XF86KbdBrightnessDown, exec, brightnessctl s 10%+"
-            ", XF86KbdBrightnessUp, exec, brightnessctl s 10%+"
-
-            # Window resizing
-            "SUPER_SHIFT, H, resizeactive, -100 0"
-            "SUPER_SHIFT, J, resizeactive, 0 100"
-            "SUPER_SHIFT, K, resizeactive, 0 -100"
-            "SUPER_SHIFT, L, resizeactive, 100 0"
-          ];
-
-          bindm = [
-            # Move/resize windows with LMB/RMB
-            "SUPER, mouse:272, movewindow"
-            "SUPER, mouse:273, resizewindow"
-          ];
         };
-      };
-
-      xdg.portal = {
-        enable = true;
-        xdgOpenUsePortal = true;
-        config.common = {
-          "org.freedesktop.impl.portal.Secret" = ["gnome-keyring"];
-          "org.freedesktop.impl.portal.ScreenCast" = ["hyprland"];
-          "org.freedesktop.impl.portal.Screenshot" = ["hyprland"];
-          # TODO: package xdg-desktop-portal-termfilechoooser so I can use yazi as default
-          "org.freedesktop.portal.FileChooser" = ["xdg-desktop-portal-gtk"];
+        dwindle = {
+          pseudotile = true;
+          preserve_split = true;
         };
-        extraPortals = [
-          pkgs.xdg-desktop-portal-gtk
-          pkgs.xdg-desktop-portal-hyprland
+
+        general = {
+          gaps_out = 10;
+        };
+        gestures.workspace_swipe = true;
+
+        input = {
+          kb_options = "caps:swapescape";
+          sensitivity = 0.2;
+          touchpad.natural_scroll = true;
+        };
+
+        master.new_status = "master";
+        misc = {
+          disable_hyprland_logo = true;
+          disable_splash_rendering = true;
+          enable_swallow = true;
+        };
+
+        xwayland.force_zero_scaling = true;
+
+        bind = [
+          # Passthrough
+          "SUPER_ALT_CTRL, R, pass, ^(com\.obsproject\.Studio)$"
+          "SUPER_ALT_CTRL, S, pass, ^(com\.obsproject\.Studio)$"
+
+          # Hotkeys
+          "SUPER, Q, exec, wlogout"
+          "SUPER, Return, exec, alacritty"
+          "SUPER, Space, exec, rofi -show-icons -show drun -l 10"
+          "SUPER, E, exec, alacritty -e 'yazi'"
+          "SUPER, C, exec, qalculate-gtk"
+          "SUPER, D, exec, hyprpicker -na"
+          "SUPER, S, exec, grim -g \"$(slurp)\" - | swappy -f - | wl-copy"
+          "SUPER, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy"
+
+          "SUPER_ALT, M, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
+          "SUPER_ALT, B, exec, ~/.config/hypr/scripts/bluetooth-toggle.sh"
+
+          # Fn keys
+          ", XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
+          ", XF86AudioPrev, exec, playerctl previous"
+          ", XF86AudioPlay, exec, playerctl play-pause"
+          ", XF86AudioNext, exec, playerctl next"
+
+          # Manipulate windows
+          "SUPER, W, killactive"
+          "SUPER, F, fullscreen"
+          "SUPER_CTRL, F, togglefloating"
+          "SUPER_CTRL, S, togglesplit"
+
+          # Focus window
+          "SUPER, H, movefocus, l"
+          "SUPER, H, alterzorder, top"
+          "SUPER, L, movefocus, r"
+          "SUPER, L, alterzorder, top"
+          "SUPER, K, movefocus, u"
+          "SUPER, K, alterzorder, top"
+          "SUPER, J, movefocus, d"
+          "SUPER, J, alterzorder, top"
+
+          # Move window
+          "SUPER_CTRL, H, movewindow, l"
+          "SUPER_CTRL, L, movewindow, r"
+          "SUPER_CTRL, K, movewindow, u"
+          "SUPER_CTRL, J, movewindow, d"
+
+          # Cycle through windows
+          "SUPER, Tab, cyclenext"
+          "SUPER, Tab, alterzorder, top"
+          "SUPER_SHIFT, Tab, cyclenext, prev"
+          "SUPER_SHIFT, Tab, alterzorder, top"
+
+          # Switch workspace
+          "SUPER, 1, workspace, 1"
+          "SUPER, 2, workspace, 2"
+          "SUPER, 3, workspace, 3"
+          "SUPER, 4, workspace, 4"
+          "SUPER, 5, workspace, 5"
+          "SUPER, 6, workspace, 6"
+
+          # Move window to workspace
+          "SUPER_SHIFT, 1, movetoworkspace, 1"
+          "SUPER_SHIFT, 2, movetoworkspace, 2"
+          "SUPER_SHIFT, 3, movetoworkspace, 3"
+          "SUPER_SHIFT, 4, movetoworkspace, 4"
+          "SUPER_SHIFT, 5, movetoworkspace, 5"
+          "SUPER_SHIFT, 6, movetoworkspace, 6"
+
+          # Scroll through workspaces
+          "SUPER_SHIFT, mouse_down, workspace, e+1"
+          "SUPER_SHIFT, mouse_up, workspace, e-1"
+        ];
+
+        binde = [
+          # Fn keys
+          ", XF86AudioRaiseVolume, exec, wpctl set-volume -l 1.25 @DEFAULT_AUDIO_SINK@ 5%+"
+          ", XF86AudioLowerVolume, exec, wpctl set-volume -l 1.25 @DEFAULT_AUDIO_SINK@ 5%-"
+          "SUPER, P, exec, ~/.config/hypr/scripts/display-toggle.sh"
+          ", XF86MonBrightnessDown, exec, brightnessctl s 10%-"
+          ", XF86MonBrightnessUp, exec, brightnessctl s 10%+"
+          ", XF86KbdBrightnessDown, exec, brightnessctl s 10%+"
+          ", XF86KbdBrightnessUp, exec, brightnessctl s 10%+"
+
+          # Window resizing
+          "SUPER_SHIFT, H, resizeactive, -100 0"
+          "SUPER_SHIFT, J, resizeactive, 0 100"
+          "SUPER_SHIFT, K, resizeactive, 0 -100"
+          "SUPER_SHIFT, L, resizeactive, 100 0"
+        ];
+
+        bindm = [
+          # Move/resize windows with LMB/RMB
+          "SUPER, mouse:272, movewindow"
+          "SUPER, mouse:273, resizewindow"
         ];
       };
     };
-  }
+
+    xdg.portal = {
+      enable = true;
+      xdgOpenUsePortal = true;
+      config.common = {
+        "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
+        "org.freedesktop.impl.portal.ScreenCast" = [ "hyprland" ];
+        "org.freedesktop.impl.portal.Screenshot" = [ "hyprland" ];
+        # TODO: package xdg-desktop-portal-termfilechoooser so I can use yazi as default
+        "org.freedesktop.portal.FileChooser" = [ "xdg-desktop-portal-gtk" ];
+      };
+      extraPortals = [
+        pkgs.xdg-desktop-portal-gtk
+        pkgs.xdg-desktop-portal-hyprland
+      ];
+    };
+  };
+}

--- a/modules/keyring.nix
+++ b/modules/keyring.nix
@@ -2,24 +2,26 @@
   config,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.home.keyring;
 in
-  with lib; {
-    options = {
-      home.keyring.enable = mkEnableOption "gnome-keyring";
-    };
+with lib;
+{
+  options = {
+    home.keyring.enable = mkEnableOption "gnome-keyring";
+  };
 
-    config = mkIf cfg.enable {
-      services = {
-        gnome-keyring = {
-          enable = true;
-          components = [
-            "pkcs11"
-            "secrets"
-            "ssh"
-          ];
-        };
+  config = mkIf cfg.enable {
+    services = {
+      gnome-keyring = {
+        enable = true;
+        components = [
+          "pkcs11"
+          "secrets"
+          "ssh"
+        ];
       };
     };
-  }
+  };
+}

--- a/modules/mpv.nix
+++ b/modules/mpv.nix
@@ -2,30 +2,32 @@
   config,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.home.mpv;
 in
-  with lib; {
-    options = {
-      home.mpv.enable = mkEnableOption "mpv media player";
-    };
+with lib;
+{
+  options = {
+    home.mpv.enable = mkEnableOption "mpv media player";
+  };
 
-    config = mkIf cfg.enable {
-      programs.mpv = {
-        enable = true;
-        config = {
-          hdr-compute-peak = "no";
-          hwdec = "auto";
-          osd-font = "sans-serif";
-          slang = "eng,en";
-          sub-auto = "fuzzy";
-          sub-font = "sans-serif";
-          sub-border-size = 1;
-          sub-color = "#CDCDCD";
-          sub-scale = 0.5;
-          sub-shadow-color = "#000000";
-          sub-shadow-offset = 2;
-        };
+  config = mkIf cfg.enable {
+    programs.mpv = {
+      enable = true;
+      config = {
+        hdr-compute-peak = "no";
+        hwdec = "auto";
+        osd-font = "sans-serif";
+        slang = "eng,en";
+        sub-auto = "fuzzy";
+        sub-font = "sans-serif";
+        sub-border-size = 1;
+        sub-color = "#CDCDCD";
+        sub-scale = 0.5;
+        sub-shadow-color = "#000000";
+        sub-shadow-offset = 2;
       };
     };
-  }
+  };
+}

--- a/modules/nvim.nix
+++ b/modules/nvim.nix
@@ -3,597 +3,701 @@
   inputs,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.home.nvim;
 in
-  with lib; {
-    imports = [
-      inputs.nixvim.homeManagerModules.nixvim
-      ./nvim/bufferline.nix
-      ./nvim/cmp.nix
-      ./nvim/conform.nix
-      ./nvim/dap.nix
-      ./nvim/lsp.nix
-      ./nvim/mini.nix
-      ./nvim/neo-tree.nix
-      ./nvim/todo-comments.nix
-      ./nvim/treesitter.nix
-      ./nvim/telescope.nix
-      ./nvim/trouble.nix
-    ];
+with lib;
+{
+  imports = [
+    inputs.nixvim.homeManagerModules.nixvim
+    ./nvim/bufferline.nix
+    ./nvim/cmp.nix
+    ./nvim/conform.nix
+    ./nvim/dap.nix
+    ./nvim/lsp.nix
+    ./nvim/mini.nix
+    ./nvim/neo-tree.nix
+    ./nvim/todo-comments.nix
+    ./nvim/treesitter.nix
+    ./nvim/telescope.nix
+    ./nvim/trouble.nix
+  ];
 
-    options = {
-      home.nvim.enable = mkEnableOption "nvim";
-    };
+  options = {
+    home.nvim.enable = mkEnableOption "nvim";
+  };
 
-    # TODO: write autocommand to open helpfiles in vertical split
-    config = mkIf cfg.enable {
-      programs = {
-        fd.enable = true;
-        fzf.enable = true;
-        ripgrep.enable = true;
-        nixvim = {
-          enable = true;
-          defaultEditor = true;
-          viAlias = true;
-          vimAlias = true;
-          vimdiffAlias = true;
-          globals.mapleader = " ";
+  # TODO: write autocommand to open helpfiles in vertical split
+  config = mkIf cfg.enable {
+    programs = {
+      fd.enable = true;
+      fzf.enable = true;
+      ripgrep.enable = true;
+      nixvim = {
+        enable = true;
+        defaultEditor = true;
+        viAlias = true;
+        vimAlias = true;
+        vimdiffAlias = true;
+        globals.mapleader = " ";
 
-          opts = {
-            autowrite = true; # write the contents of the file automatically on certain commands
-            clipboard = "unnamedplus"; # use system clipboard
-            completeopt = "menu,menuone,noselect";
-            confirm = true; # confirm to save changes before exiting modified buffer
-            cursorline = true; # enable highlighting of the current line
-            expandtab = true; # use spaces instead of tabs
-            foldmethod = "expr"; # fold level of a line
-            foldtext = "";
-            formatoptions = "jcroqlnt"; # default: tcqj
-            grepformat = "%f:%l:%c:%m";
-            grepprg = "rg --vimgrep";
-            ignorecase = true; # enable case insensitive search
-            inccommand = "nosplit"; # show effects of a command incrementally in the buffer
-            jumpoptions = "view";
-            laststatus = 3; # global status line
-            linebreak = true; # wrap lines at convenient points
-            list = true; # show invisible characters
-            listchars = "extends:›,nbsp:␣,precedes:‹,tab:»\ ,trail:·";
-            mouse = "a"; # enable mouse mode
-            number = true; # show line numbers
-            relativenumber = true; # relative line numbers
-            softtabstop = 2; # number of spaces that represent a <TAB>
-            smartcase = true; # don't ignore case when using capital letters
-            smartindent = true; # insert indents automatically
-            spelllang = ["en" "nl"];
-            shiftround = true; # round indent
-            shiftwidth = 2; # size of indent
-            showmode = false; # don't show mode as we are using a statusline
-            smoothscroll = true;
-            splitkeep = "screen"; # keep the text on the same line
-            splitbelow = true; # put new windows below current
-            splitright = true; # put new windows right of current
-            tabstop = 2; # number of spaces tabs count for
-            termguicolors = true; # true color support
-            undofile = true;
-            undolevels = 10000;
-            updatetime = 200; # save swap file and trigger CursorHold
-            virtualedit = "block"; # allow cursor to move where there is no text in visual block mode
-            winminwidth = 5; # minim window width
-            wrap = false; # disable line wrap
+        opts = {
+          autowrite = true; # write the contents of the file automatically on certain commands
+          clipboard = "unnamedplus"; # use system clipboard
+          completeopt = "menu,menuone,noselect";
+          confirm = true; # confirm to save changes before exiting modified buffer
+          cursorline = true; # enable highlighting of the current line
+          expandtab = true; # use spaces instead of tabs
+          foldmethod = "expr"; # fold level of a line
+          foldtext = "";
+          formatoptions = "jcroqlnt"; # default: tcqj
+          grepformat = "%f:%l:%c:%m";
+          grepprg = "rg --vimgrep";
+          ignorecase = true; # enable case insensitive search
+          inccommand = "nosplit"; # show effects of a command incrementally in the buffer
+          jumpoptions = "view";
+          laststatus = 3; # global status line
+          linebreak = true; # wrap lines at convenient points
+          list = true; # show invisible characters
+          listchars = "extends:›,nbsp:␣,precedes:‹,tab:»\ ,trail:·";
+          mouse = "a"; # enable mouse mode
+          number = true; # show line numbers
+          relativenumber = true; # relative line numbers
+          softtabstop = 2; # number of spaces that represent a <TAB>
+          smartcase = true; # don't ignore case when using capital letters
+          smartindent = true; # insert indents automatically
+          spelllang = [
+            "en"
+            "nl"
+          ];
+          shiftround = true; # round indent
+          shiftwidth = 2; # size of indent
+          showmode = false; # don't show mode as we are using a statusline
+          smoothscroll = true;
+          splitkeep = "screen"; # keep the text on the same line
+          splitbelow = true; # put new windows below current
+          splitright = true; # put new windows right of current
+          tabstop = 2; # number of spaces tabs count for
+          termguicolors = true; # true color support
+          undofile = true;
+          undolevels = 10000;
+          updatetime = 200; # save swap file and trigger CursorHold
+          virtualedit = "block"; # allow cursor to move where there is no text in visual block mode
+          winminwidth = 5; # minim window width
+          wrap = false; # disable line wrap
+        };
+
+        keymaps =
+          [
+            # save file
+            {
+              mode = [
+                "i"
+                "x"
+                "n"
+                "s"
+              ];
+              key = "<C-s>";
+              action = "<cmd>w<cr><esc>";
+              options = {
+                desc = "Save File";
+              };
+            }
+
+            # quit all
+            {
+              mode = "n";
+              key = "<leader>qq";
+              action = "<cmd>qa<cr>";
+              options = {
+                desc = "Quit All";
+              };
+            }
+
+            # better up/down
+            {
+              mode = [
+                "n"
+                "x"
+              ];
+              key = "j";
+              action = "v:count == 0 ? 'gj' : 'j'";
+              options = {
+                expr = true;
+                silent = true;
+              };
+            }
+            {
+              mode = [
+                "n"
+                "x"
+              ];
+              key = "<Down>";
+              action = "v:count == 0 ? 'gj' : 'j'";
+              options = {
+                expr = true;
+                silent = true;
+              };
+            }
+            {
+              mode = [
+                "n"
+                "x"
+              ];
+              key = "k";
+              action = "v:count == 0 ? 'gk' : 'k'";
+              options = {
+                expr = true;
+                silent = true;
+              };
+            }
+            {
+              mode = [
+                "n"
+                "x"
+              ];
+              key = "<Up>";
+              action = "v:count == 0 ? 'gk' : 'k'";
+              options = {
+                expr = true;
+                silent = true;
+              };
+            }
+
+            # move to window using <ctrl> hjkl keys
+            {
+              mode = "n";
+              key = "<C-h>";
+              action = "<C-w>h";
+              options = {
+                desc = "Go to Left Window";
+                remap = true;
+              };
+            }
+            {
+              mode = "n";
+              key = "<C-j>";
+              action = "<C-w>j";
+              options = {
+                desc = "Go to Lower Window";
+                remap = true;
+              };
+            }
+            {
+              mode = "n";
+              key = "<C-k>";
+              action = "<C-w>k";
+              options = {
+                desc = "Go to Upper Window";
+                remap = true;
+              };
+            }
+            {
+              mode = "n";
+              key = "<C-l>";
+              action = "<C-w>l";
+              options = {
+                desc = "Go to Right Window";
+                remap = true;
+              };
+            }
+
+            # resize window using the <ctrl> arrow keys
+            {
+              mode = "n";
+              key = "<C-Up>";
+              action = "<cmd>resize +2<cr>";
+              options = {
+                desc = "Increase Window Height";
+              };
+            }
+            {
+              mode = "n";
+              key = "<C-Down>";
+              action = "<cmd>resize -2<cr>";
+              options = {
+                desc = "Decrease Window Height";
+              };
+            }
+            {
+              mode = "n";
+              key = "<C-Left>";
+              action = "<cmd>vertical resize -2<cr>";
+              options = {
+                desc = "Decrease Window Width";
+              };
+            }
+            {
+              mode = "n";
+              key = "<C-Right>";
+              action = "<cmd>vertical resize +2<cr>";
+              options = {
+                desc = "Increase Window Width";
+              };
+            }
+
+            # move lines around using the <alt> hjkl keys
+            {
+              mode = "n";
+              key = "<A-j>";
+              action = "<cmd>m .+1<cr>==";
+              options = {
+                desc = "Move Down";
+              };
+            }
+            {
+              mode = "n";
+              key = "<A-k>";
+              action = "<cmd>m .-2<cr>==";
+              options = {
+                desc = "Move Up";
+              };
+            }
+            {
+              mode = "i";
+              key = "<A-j>";
+              action = "<esc><cmd>m .+1<cr>==gi";
+              options = {
+                desc = "Move Down";
+              };
+            }
+            {
+              mode = "i";
+              key = "<A-k>";
+              action = "<esc><cmd>m .-2<cr>==gi";
+              options = {
+                desc = "Move Up";
+              };
+            }
+            {
+              mode = "v";
+              key = "<A-j>";
+              action = ":m '>+1<cr>gv=gv";
+              options = {
+                desc = "Move Down";
+              };
+            }
+            {
+              mode = "v";
+              key = "<A-k>";
+              action = ":m '<-2<cr>gv=gv";
+              options = {
+                desc = "Move Up";
+              };
+            }
+
+            # buffers
+            {
+              mode = [ "n" ];
+              key = "<S-h>";
+              action = "<cmd>bprevious<cr>";
+              options = {
+                desc = "Prev Buffer";
+              };
+            }
+            {
+              mode = [ "n" ];
+              key = "<leader>bb";
+              action = "<cmd>e #<br>";
+              options = {
+                desc = "Switch to Other Buffer";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader>bd";
+              action = "<cmd>bdelete<cr>";
+              options = {
+                desc = "Delete Buffer";
+              };
+            }
+
+            # clear search with <esc>
+            {
+              mode = [
+                "i"
+                "n"
+              ];
+              key = "<esc>";
+              action = "<cmd>noh<cr><esc>";
+              options = {
+                desc = "Escape and Clear hlsearch";
+              };
+            }
+
+            # clear search, diff update and redraw
+            {
+              mode = "n";
+              key = "<leader>ur";
+              action = "<Cmd>nohlsearch<Bar>diffupdate<Bar>normal! <C-L><CR>";
+              options = {
+                desc = "Redraw / Clear hlsearch / Diff Update";
+              };
+            }
+
+            # https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n
+            {
+              mode = "n";
+              key = "n";
+              action = "'Nn'[v:searchforward].'zv'";
+              options = {
+                expr = true;
+                desc = "Next Search Result";
+              };
+            }
+            {
+              mode = "x";
+              key = "n";
+              action = "'Nn'[v:searchforward]";
+              options = {
+                expr = true;
+                desc = "Next Search Result";
+              };
+            }
+            {
+              mode = "o";
+              key = "n";
+              action = "'Nn'[v:searchforward]";
+              options = {
+                expr = true;
+                desc = "Next Search Result";
+              };
+            }
+            {
+              mode = "n";
+              key = "N";
+              action = "'nN'[v:searchforward].'zv'";
+              options = {
+                expr = true;
+                desc = "Prev Search Result";
+              };
+            }
+            {
+              mode = "x";
+              key = "N";
+              action = "'nN'[v:searchforward]";
+              options = {
+                expr = true;
+                desc = "Prev Search Result";
+              };
+            }
+            {
+              mode = "o";
+              key = "N";
+              action = "'nN'[v:searchforward]";
+              options = {
+                expr = true;
+                desc = "Prev Search Result";
+              };
+            }
+
+            # better indenting
+            {
+              mode = "v";
+              key = "<";
+              action = "<gv";
+            }
+            {
+              mode = "v";
+              key = ">";
+              action = ">gv";
+            }
+
+            # diagnostics
+            {
+              mode = "n";
+              key = "<leader>cd";
+              action = "vim.diagnostic.open_float";
+              options = {
+                desc = "Line Diagnostics";
+              };
+            }
+            {
+              mode = "n";
+              key = "]d";
+              action = "diagnostic_goto(true)";
+              options = {
+                desc = "Next Diagnostic";
+              };
+            }
+            {
+              mode = "n";
+              key = "[d";
+              action = "diagnostic_goto(false)";
+              options = {
+                desc = "Prev Diagnostic";
+              };
+            }
+            {
+              mode = "n";
+              key = "]e";
+              action = "diagnostic_goto(true 'ERROR')";
+              options = {
+                desc = "Next Error";
+              };
+            }
+            {
+              mode = "n";
+              key = "[e";
+              action = "diagnostic_goto(false 'ERROR')";
+              options = {
+                desc = "Prev Error";
+              };
+            }
+            {
+              mode = "n";
+              key = "]w";
+              action = "diagnostic_goto(true 'WARN')";
+              options = {
+                desc = "Next Warning";
+              };
+            }
+            {
+              mode = "n";
+              key = "[w";
+              action = "diagnostic_goto(false 'WARN')";
+              options = {
+                desc = "Prev Warning";
+              };
+            }
+
+            # commenting
+            {
+              mode = "n";
+              key = "gco";
+              action = "o<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>";
+              options = {
+                desc = "Add Comment Below";
+              };
+            }
+            {
+              mode = "n";
+              key = "gcO";
+              action = "O<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>";
+              options = {
+                desc = "Add Comment Above";
+              };
+            }
+
+            # highlight under cursor
+            {
+              mode = "n";
+              key = "<leader>ui";
+              action = "vim.show_pos";
+              options = {
+                desc = "Inspect Pos";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader>uI";
+              action = "<cmd>InspectTree<cr>";
+              options = {
+                desc = "Inspect Tree";
+              };
+            }
+
+            # terminal mappings
+            {
+              mode = "t";
+              key = "<esc><esc>";
+              action = "<c-\\><c-n>";
+              options = {
+                desc = "Enter Normal Mode";
+              };
+            }
+            {
+              mode = "t";
+              key = "<C-h>";
+              action = "<cmd>wincmd h<cr>";
+              options = {
+                desc = "Go to Left Window";
+              };
+            }
+            {
+              mode = "t";
+              key = "<C-j>";
+              action = "<cmd>wincmd j<cr>";
+              options = {
+                desc = "Go to Lower Window";
+              };
+            }
+            {
+              mode = "t";
+              key = "<C-k>";
+              action = "<cmd>wincmd k<cr>";
+              options = {
+                desc = "Go to Upper Window";
+              };
+            }
+            {
+              mode = "t";
+              key = "<C-l>";
+              action = "<cmd>wincmd l<cr>";
+              options = {
+                desc = "Go to Right Window";
+              };
+            }
+            {
+              mode = "t";
+              key = "<C-/>";
+              action = "<cmd>close<cr>";
+              options = {
+                desc = "Hide Terminal";
+              };
+            }
+
+            # window management
+            {
+              mode = "n";
+              key = "<leader>w";
+              action = "<C-W>";
+              options = {
+                desc = "Windows";
+                remap = true;
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader>-";
+              action = "<C-W>s";
+              options = {
+                desc = "Split Window Below";
+                remap = true;
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader>|";
+              action = "<C-W>v";
+              options = {
+                desc = "Split Window Right";
+                remap = true;
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader>wd";
+              action = "<C-W>c";
+              options = {
+                desc = "Delete Window";
+                remap = true;
+              };
+            }
+
+            # tabs
+            {
+              mode = "n";
+              key = "<leader><tab>l";
+              action = "<cmd>tablast<cr>";
+              options = {
+                desc = "Last Tab";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader><tab>f";
+              action = "<cmd>tabfirst<cr>";
+              options = {
+                desc = "First Tab";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader><tab><tab>";
+              action = "<cmd>tabnew<cr>";
+              options = {
+                desc = "New Tab";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader><tab>]";
+              action = "<cmd>tabnext<cr>";
+              options = {
+                desc = "Next Tab";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader><tab>d";
+              action = "<cmd>tabclose<cr>";
+              options = {
+                desc = "Close Tab";
+              };
+            }
+            {
+              mode = "n";
+              key = "<leader><tab>[";
+              action = "<cmd>tabprevious<cr>";
+              options = {
+                desc = "Previous Tab";
+              };
+            }
+          ]
+          ++ optionals config.programs.lazygit.enable [
+            {
+              mode = "n";
+              key = "<leader>gg";
+              action = "<cmd>LazyGit<cr>";
+              options = {
+                desc = "LazyGit (cwd)";
+              };
+            }
+          ];
+
+        plugins = {
+          conform-nvim.enable = true; # formatting
+          dashboard.enable = true;
+          flash = {
+            enable = true;
+            settings.modes = {
+              char.jump_labels = true;
+              search.enabled = true;
+            };
           };
-
-          keymaps =
-            [
-              # save file
-              {
-                mode = ["i" "x" "n" "s"];
-                key = "<C-s>";
-                action = "<cmd>w<cr><esc>";
-                options = {desc = "Save File";};
-              }
-
-              # quit all
-              {
-                mode = "n";
-                key = "<leader>qq";
-                action = "<cmd>qa<cr>";
-                options = {desc = "Quit All";};
-              }
-
-              # better up/down
-              {
-                mode = ["n" "x"];
-                key = "j";
-                action = "v:count == 0 ? 'gj' : 'j'";
-                options = {
-                  expr = true;
-                  silent = true;
-                };
-              }
-              {
-                mode = ["n" "x"];
-                key = "<Down>";
-                action = "v:count == 0 ? 'gj' : 'j'";
-                options = {
-                  expr = true;
-                  silent = true;
-                };
-              }
-              {
-                mode = ["n" "x"];
-                key = "k";
-                action = "v:count == 0 ? 'gk' : 'k'";
-                options = {
-                  expr = true;
-                  silent = true;
-                };
-              }
-              {
-                mode = ["n" "x"];
-                key = "<Up>";
-                action = "v:count == 0 ? 'gk' : 'k'";
-                options = {
-                  expr = true;
-                  silent = true;
-                };
-              }
-
-              # move to window using <ctrl> hjkl keys
-              {
-                mode = "n";
-                key = "<C-h>";
-                action = "<C-w>h";
-                options = {
-                  desc = "Go to Left Window";
-                  remap = true;
-                };
-              }
-              {
-                mode = "n";
-                key = "<C-j>";
-                action = "<C-w>j";
-                options = {
-                  desc = "Go to Lower Window";
-                  remap = true;
-                };
-              }
-              {
-                mode = "n";
-                key = "<C-k>";
-                action = "<C-w>k";
-                options = {
-                  desc = "Go to Upper Window";
-                  remap = true;
-                };
-              }
-              {
-                mode = "n";
-                key = "<C-l>";
-                action = "<C-w>l";
-                options = {
-                  desc = "Go to Right Window";
-                  remap = true;
-                };
-              }
-
-              # resize window using the <ctrl> arrow keys
-              {
-                mode = "n";
-                key = "<C-Up>";
-                action = "<cmd>resize +2<cr>";
-                options = {desc = "Increase Window Height";};
-              }
-              {
-                mode = "n";
-                key = "<C-Down>";
-                action = "<cmd>resize -2<cr>";
-                options = {desc = "Decrease Window Height";};
-              }
-              {
-                mode = "n";
-                key = "<C-Left>";
-                action = "<cmd>vertical resize -2<cr>";
-                options = {desc = "Decrease Window Width";};
-              }
-              {
-                mode = "n";
-                key = "<C-Right>";
-                action = "<cmd>vertical resize +2<cr>";
-                options = {desc = "Increase Window Width";};
-              }
-
-              # move lines around using the <alt> hjkl keys
-              {
-                mode = "n";
-                key = "<A-j>";
-                action = "<cmd>m .+1<cr>==";
-                options = {desc = "Move Down";};
-              }
-              {
-                mode = "n";
-                key = "<A-k>";
-                action = "<cmd>m .-2<cr>==";
-                options = {desc = "Move Up";};
-              }
-              {
-                mode = "i";
-                key = "<A-j>";
-                action = "<esc><cmd>m .+1<cr>==gi";
-                options = {desc = "Move Down";};
-              }
-              {
-                mode = "i";
-                key = "<A-k>";
-                action = "<esc><cmd>m .-2<cr>==gi";
-                options = {desc = "Move Up";};
-              }
-              {
-                mode = "v";
-                key = "<A-j>";
-                action = ":m '>+1<cr>gv=gv";
-                options = {desc = "Move Down";};
-              }
-              {
-                mode = "v";
-                key = "<A-k>";
-                action = ":m '<-2<cr>gv=gv";
-                options = {desc = "Move Up";};
-              }
-
-              # buffers
-              {
-                mode = ["n"];
-                key = "<S-h>";
-                action = "<cmd>bprevious<cr>";
-                options = {desc = "Prev Buffer";};
-              }
-              {
-                mode = ["n"];
-                key = "<leader>bb";
-                action = "<cmd>e #<br>";
-                options = {desc = "Switch to Other Buffer";};
-              }
-              {
-                mode = "n";
-                key = "<leader>bd";
-                action = "<cmd>bdelete<cr>";
-                options = {
-                  desc = "Delete Buffer";
-                };
-              }
-
-              # clear search with <esc>
-              {
-                mode = ["i" "n"];
-                key = "<esc>";
-                action = "<cmd>noh<cr><esc>";
-                options = {desc = "Escape and Clear hlsearch";};
-              }
-
-              # clear search, diff update and redraw
-              {
-                mode = "n";
-                key = "<leader>ur";
-                action = "<Cmd>nohlsearch<Bar>diffupdate<Bar>normal! <C-L><CR>";
-                options = {desc = "Redraw / Clear hlsearch / Diff Update";};
-              }
-
-              # https://github.com/mhinz/vim-galore#saner-behavior-of-n-and-n
-              {
-                mode = "n";
-                key = "n";
-                action = "'Nn'[v:searchforward].'zv'";
-                options = {
-                  expr = true;
-                  desc = "Next Search Result";
-                };
-              }
-              {
-                mode = "x";
-                key = "n";
-                action = "'Nn'[v:searchforward]";
-                options = {
-                  expr = true;
-                  desc = "Next Search Result";
-                };
-              }
-              {
-                mode = "o";
-                key = "n";
-                action = "'Nn'[v:searchforward]";
-                options = {
-                  expr = true;
-                  desc = "Next Search Result";
-                };
-              }
-              {
-                mode = "n";
-                key = "N";
-                action = "'nN'[v:searchforward].'zv'";
-                options = {
-                  expr = true;
-                  desc = "Prev Search Result";
-                };
-              }
-              {
-                mode = "x";
-                key = "N";
-                action = "'nN'[v:searchforward]";
-                options = {
-                  expr = true;
-                  desc = "Prev Search Result";
-                };
-              }
-              {
-                mode = "o";
-                key = "N";
-                action = "'nN'[v:searchforward]";
-                options = {
-                  expr = true;
-                  desc = "Prev Search Result";
-                };
-              }
-
-              # better indenting
-              {
-                mode = "v";
-                key = "<";
-                action = "<gv";
-              }
-              {
-                mode = "v";
-                key = ">";
-                action = ">gv";
-              }
-
-              # diagnostics
-              {
-                mode = "n";
-                key = "<leader>cd";
-                action = "vim.diagnostic.open_float";
-                options = {desc = "Line Diagnostics";};
-              }
-              {
-                mode = "n";
-                key = "]d";
-                action = "diagnostic_goto(true)";
-                options = {desc = "Next Diagnostic";};
-              }
-              {
-                mode = "n";
-                key = "[d";
-                action = "diagnostic_goto(false)";
-                options = {desc = "Prev Diagnostic";};
-              }
-              {
-                mode = "n";
-                key = "]e";
-                action = "diagnostic_goto(true 'ERROR')";
-                options = {desc = "Next Error";};
-              }
-              {
-                mode = "n";
-                key = "[e";
-                action = "diagnostic_goto(false 'ERROR')";
-                options = {desc = "Prev Error";};
-              }
-              {
-                mode = "n";
-                key = "]w";
-                action = "diagnostic_goto(true 'WARN')";
-                options = {desc = "Next Warning";};
-              }
-              {
-                mode = "n";
-                key = "[w";
-                action = "diagnostic_goto(false 'WARN')";
-                options = {desc = "Prev Warning";};
-              }
-
-              # commenting
-              {
-                mode = "n";
-                key = "gco";
-                action = "o<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>";
-                options = {desc = "Add Comment Below";};
-              }
-              {
-                mode = "n";
-                key = "gcO";
-                action = "O<esc>Vcx<esc><cmd>normal gcc<cr>fxa<bs>";
-                options = {desc = "Add Comment Above";};
-              }
-
-              # highlight under cursor
-              {
-                mode = "n";
-                key = "<leader>ui";
-                action = "vim.show_pos";
-                options = {desc = "Inspect Pos";};
-              }
-              {
-                mode = "n";
-                key = "<leader>uI";
-                action = "<cmd>InspectTree<cr>";
-                options = {desc = "Inspect Tree";};
-              }
-
-              # terminal mappings
-              {
-                mode = "t";
-                key = "<esc><esc>";
-                action = "<c-\\><c-n>";
-                options = {desc = "Enter Normal Mode";};
-              }
-              {
-                mode = "t";
-                key = "<C-h>";
-                action = "<cmd>wincmd h<cr>";
-                options = {desc = "Go to Left Window";};
-              }
-              {
-                mode = "t";
-                key = "<C-j>";
-                action = "<cmd>wincmd j<cr>";
-                options = {desc = "Go to Lower Window";};
-              }
-              {
-                mode = "t";
-                key = "<C-k>";
-                action = "<cmd>wincmd k<cr>";
-                options = {desc = "Go to Upper Window";};
-              }
-              {
-                mode = "t";
-                key = "<C-l>";
-                action = "<cmd>wincmd l<cr>";
-                options = {desc = "Go to Right Window";};
-              }
-              {
-                mode = "t";
-                key = "<C-/>";
-                action = "<cmd>close<cr>";
-                options = {desc = "Hide Terminal";};
-              }
-
-              # window management
-              {
-                mode = "n";
-                key = "<leader>w";
-                action = "<C-W>";
-                options = {
-                  desc = "Windows";
-                  remap = true;
-                };
-              }
-              {
-                mode = "n";
-                key = "<leader>-";
-                action = "<C-W>s";
-                options = {
-                  desc = "Split Window Below";
-                  remap = true;
-                };
-              }
-              {
-                mode = "n";
-                key = "<leader>|";
-                action = "<C-W>v";
-                options = {
-                  desc = "Split Window Right";
-                  remap = true;
-                };
-              }
-              {
-                mode = "n";
-                key = "<leader>wd";
-                action = "<C-W>c";
-                options = {
-                  desc = "Delete Window";
-                  remap = true;
-                };
-              }
-
-              # tabs
-              {
-                mode = "n";
-                key = "<leader><tab>l";
-                action = "<cmd>tablast<cr>";
-                options = {desc = "Last Tab";};
-              }
-              {
-                mode = "n";
-                key = "<leader><tab>f";
-                action = "<cmd>tabfirst<cr>";
-                options = {desc = "First Tab";};
-              }
-              {
-                mode = "n";
-                key = "<leader><tab><tab>";
-                action = "<cmd>tabnew<cr>";
-                options = {desc = "New Tab";};
-              }
-              {
-                mode = "n";
-                key = "<leader><tab>]";
-                action = "<cmd>tabnext<cr>";
-                options = {desc = "Next Tab";};
-              }
-              {
-                mode = "n";
-                key = "<leader><tab>d";
-                action = "<cmd>tabclose<cr>";
-                options = {desc = "Close Tab";};
-              }
-              {
-                mode = "n";
-                key = "<leader><tab>[";
-                action = "<cmd>tabprevious<cr>";
-                options = {desc = "Previous Tab";};
-              }
-            ]
-            ++ optionals config.programs.lazygit.enable [
-              # lazygit
-              {
-                mode = "n";
-                key = "<leader>gg";
-                action = "<cmd>LazyGit<cr>";
-                options = {desc = "LazyGit (cwd)";};
-              }
-            ];
-
-          plugins = {
-            conform-nvim.enable = true; # formatting
-            dashboard.enable = true;
-            flash = {
-              enable = true;
-              settings.modes = {
-                char.jump_labels = true;
-                search.enabled = true;
+          friendly-snippets.enable = true;
+          gitsigns.enable = true;
+          indent-blankline = {
+            enable = true;
+            settings = {
+              exclude = {
+                filetypes = [
+                  "help"
+                  "alpha"
+                  "dashboard"
+                  "neo-tree"
+                  "Trouble"
+                  "trouble"
+                  "notify"
+                ];
+              };
+              indent = {
+                char = "│";
+              };
+              scope = {
+                show_end = false;
+                show_start = true;
               };
             };
-            friendly-snippets.enable = true;
-            gitsigns.enable = true;
-            indent-blankline = {
-              enable = true;
-              settings = {
-                exclude = {
-                  filetypes = [
-                    "help"
-                    "alpha"
-                    "dashboard"
-                    "neo-tree"
-                    "Trouble"
-                    "trouble"
-                    "notify"
-                  ];
-                };
-                indent = {
-                  char = "│";
-                };
-                scope = {
-                  show_end = false;
-                  show_start = true;
-                };
-              };
-            };
-            lazygit.enable = config.programs.lazygit.enable;
-            lint.enable = true; # linting
-            lualine.enable = true;
-            noice.enable = true;
-            notify = {
-              enable = true;
-              timeout = 1000;
-            };
-            schemastore.enable = true;
-            ts-autotag.enable = true;
-            ts-comments.enable = true;
-            undotree.enable = true;
-            web-devicons.enable = true;
-            which-key.enable = true;
           };
+          lazygit.enable = config.programs.lazygit.enable;
+          lint.enable = true; # linting
+          lualine.enable = true;
+          noice.enable = true;
+          notify = {
+            enable = true;
+            timeout = 1000;
+          };
+          schemastore.enable = true;
+          ts-autotag.enable = true;
+          ts-comments.enable = true;
+          undotree.enable = true;
+          web-devicons.enable = true;
+          which-key.enable = true;
         };
       };
     };
-  }
+  };
+}

--- a/modules/nvim/bufferline.nix
+++ b/modules/nvim/bufferline.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
       {

--- a/modules/nvim/cmp.nix
+++ b/modules/nvim/cmp.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
     ];
@@ -8,7 +9,11 @@
         enable = true;
         autoEnableSources = true;
         settings = {
-          formatting.fields = ["kind" "abbr" "menu"];
+          formatting.fields = [
+            "kind"
+            "abbr"
+            "menu"
+          ];
           mapping = {
             "<C-b>" = "cmp.mapping.scroll_docs(-4)";
             "<C-f>" = "cmp.mapping.scroll_docs(4)";
@@ -28,13 +33,13 @@
           };
           snippet.expand = "luasnip";
           sources = [
-            {name = "emoji";}
-            {name = "buffer";}
-            {name = "cmdline";}
-            {name = "dap";}
-            {name = "luasnip";}
-            {name = "nvim_lsp";}
-            {name = "path";}
+            { name = "emoji"; }
+            { name = "buffer"; }
+            { name = "cmdline"; }
+            { name = "dap"; }
+            { name = "luasnip"; }
+            { name = "nvim_lsp"; }
+            { name = "path"; }
           ];
         };
       };

--- a/modules/nvim/conform.nix
+++ b/modules/nvim/conform.nix
@@ -2,7 +2,9 @@
   lib,
   pkgs,
   ...
-}: {
+}:
+with lib;
+{
   programs.nixvim = {
     keymaps = [
     ];
@@ -70,7 +72,7 @@
             "markdownfmt"
           ];
           nix = [
-            "alejandra"
+            "nixfmt-rfc-style"
           ];
           php = {
             __unkeyed-1 = "pint";
@@ -93,9 +95,9 @@
           };
         };
 
-        formatters = {
-          alejandra = {
-            command = "${lib.getExe pkgs.alejandra}";
+        formatters = with pkgs; {
+          nixfmt-rfc-style = {
+            command = "${getExe nixfmt-rfc-style}";
           };
           black = {
             command = "${lib.getExe pkgs.black}";

--- a/modules/nvim/conform.nix
+++ b/modules/nvim/conform.nix
@@ -12,7 +12,7 @@ with lib;
     plugins.conform-nvim = {
       enable = true;
       settings = {
-        format_on_save = ''
+        format_on_save.__raw = ''
           function(bufnr)
             if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then
               return
@@ -27,7 +27,7 @@ with lib;
            end
         '';
 
-        format_after_save = ''
+        format_after_save.__raw = ''
           function(bufnr)
             if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then
               return
@@ -46,9 +46,11 @@ with lib;
             # "shellharden"
             # "shfmt"
           ];
-          css = [
-            "stylelint"
-          ];
+          css = {
+            __unkeyed-1 = "stylelint";
+            __unkeyed-2 = "eslint_d";
+            stop_after_first = true;
+          };
           html = {
             __unkeyed-1 = "superhtml";
             __unkeyed-2 = "eslint_d";
@@ -62,15 +64,19 @@ with lib;
             __unkeyed-3 = "prettier";
             stop_after_first = true;
           };
-          json = [
-            "jq"
-          ];
+          json = {
+            __unkeyed-1 = "jq";
+            __unkeyed-2 = "eslint_d";
+            stop_after_first = true;
+          };
           lua = [
             "stylua"
           ];
-          markdown = [
-            "markdownfmt"
-          ];
+          markdown = {
+            __unkeyed-1 = "markdownfmt";
+            __unkeyed-2 = "eslint_d";
+            stop_after_first = true;
+          };
           nix = [
             "nixfmt-rfc-style"
           ];
@@ -100,34 +106,34 @@ with lib;
             command = "${getExe nixfmt-rfc-style}";
           };
           black = {
-            command = "${lib.getExe pkgs.black}";
+            command = "${getExe black}";
           };
           eslint_d = {
-            command = "${lib.getExe pkgs.eslint_d}";
+            command = "${getExe eslint_d}";
           };
           isort = {
-            command = "${lib.getExe pkgs.isort}";
+            command = "${getExe isort}";
           };
           jq = {
-            command = "${lib.getExe pkgs.jq}";
+            command = "${getExe jq}";
           };
           prettierd = {
-            command = "${lib.getExe pkgs.prettierd}";
+            command = "${getExe prettierd}";
           };
           php_cs_fixer = {
-            command = "${lib.getExe pkgs.php83Packages.php-cs-fixer}";
+            command = "${getExe php83Packages.php-cs-fixer}";
           };
           shellcheck = {
-            command = "${lib.getExe pkgs.shellcheck}";
+            command = "${getExe shellcheck}";
           };
           shellharden = {
-            command = "${lib.getExe pkgs.shellharden}";
+            command = "${getExe shellharden}";
           };
           shfmt = {
-            command = "${lib.getExe pkgs.shfmt}";
+            command = "${getExe shfmt}";
           };
           stylua = {
-            command = "${lib.getExe pkgs.stylua}";
+            command = "${getExe stylua}";
           };
         };
 

--- a/modules/nvim/dap.nix
+++ b/modules/nvim/dap.nix
@@ -1,43 +1,57 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
       {
-        mode = ["n" "v"];
+        mode = [
+          "n"
+          "v"
+        ];
         key = "<leader>d";
         action = "";
-        options = {desc = "+debug";};
+        options = {
+          desc = "+debug";
+        };
       }
       {
-        mode = ["n"];
+        mode = [ "n" ];
         key = "<leader>dB";
         action = ''
           function() require("dap").set_breakpoint(vim.fn.input('Breakpoint condition: ')) end;
         '';
-        options = {desc = "Breakpoint Condition";};
+        options = {
+          desc = "Breakpoint Condition";
+        };
       }
       {
-        mode = ["n"];
+        mode = [ "n" ];
         key = "<leader>db";
         action = ''
           function() require("dap").toggle_breakpoint() end;
         '';
-        options = {desc = "Toggle Breakpoint";};
+        options = {
+          desc = "Toggle Breakpoint";
+        };
       }
       {
-        mode = ["n"];
+        mode = [ "n" ];
         key = "<leader>dc";
         action = ''
           function() require("dap").continue() end;
         '';
-        options = {desc = "Continue";};
+        options = {
+          desc = "Continue";
+        };
       }
       {
-        mode = ["n"];
+        mode = [ "n" ];
         key = "<leader>da";
         action = ''
           function() require("dap").continue({ before = get_args }) end;
         '';
-        options = {desc = "Run with Args";};
+        options = {
+          desc = "Run with Args";
+        };
       }
       # { mode = "n"; "<leader>dC"; function() require("dap").run_to_cursor() end; desc = "Run to Cursor" };
       # { mode = "n"; "<leader>dg"; function() require("dap").goto_() end; desc = "Go to Line (No Execute)" };

--- a/modules/nvim/lsp.nix
+++ b/modules/nvim/lsp.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
     ];

--- a/modules/nvim/mini.nix
+++ b/modules/nvim/mini.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
     ];
@@ -11,14 +12,14 @@
             n_lines = 50;
             search_method = "cover_or_next";
           };
-          icons = {};
+          icons = { };
           pairs = {
             modes = {
               insert = true;
               command = true;
               terminal = false;
             };
-            skip_ts = ["string"];
+            skip_ts = [ "string" ];
             skip_unbalanced = true;
             markdown = true;
           };

--- a/modules/nvim/neo-tree.nix
+++ b/modules/nvim/neo-tree.nix
@@ -1,17 +1,25 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
       {
-        mode = ["n"];
+        mode = [ "n" ];
         key = "<leader>e";
         action = "<cmd>Neotree toggle<cr>";
-        options = {desc = "Open/Close Neotree";};
+        options = {
+          desc = "Open/Close Neotree";
+        };
       }
     ];
 
     plugins.neo-tree = {
       enable = true;
-      sources = ["filesystem" "buffers" "git_status" "document_symbols"];
+      sources = [
+        "filesystem"
+        "buffers"
+        "git_status"
+        "document_symbols"
+      ];
       closeIfLastWindow = true;
       filesystem = {
         bindToCwd = false;

--- a/modules/nvim/telescope.nix
+++ b/modules/nvim/telescope.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
       {

--- a/modules/nvim/todo-comments.nix
+++ b/modules/nvim/todo-comments.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
       {

--- a/modules/nvim/treesitter.nix
+++ b/modules/nvim/treesitter.nix
@@ -1,4 +1,5 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
     ];

--- a/modules/nvim/trouble.nix
+++ b/modules/nvim/trouble.nix
@@ -1,41 +1,54 @@
-{...}: {
+{ ... }:
+{
   programs.nixvim = {
     keymaps = [
       {
         mode = "n";
         key = "<leader>xx";
         action = "<cmd>Trouble diagnostics toggle<cr>";
-        options = {desc = "Diagnostics (Trouble)";};
+        options = {
+          desc = "Diagnostics (Trouble)";
+        };
       }
       {
         mode = "n";
         key = "<leader>xX";
         action = "<cmd>Trouble diagnostics toggle filter.buf=0<cr>";
-        options = {desc = "Buffer Diagnostics (Trouble)";};
+        options = {
+          desc = "Buffer Diagnostics (Trouble)";
+        };
       }
       {
         mode = "n";
         key = "<leader>cs";
         action = "<cmd>Trouble symbols toggle focus=false<cr>";
-        options = {desc = "Symbols (Trouble)";};
+        options = {
+          desc = "Symbols (Trouble)";
+        };
       }
       {
         mode = "n";
         key = "<leader>cl";
         action = "<cmd>Trouble lsp toggle focus=false win.position=right<cr>";
-        options = {desc = "LSP Definitions / References / ... (Trouble)";};
+        options = {
+          desc = "LSP Definitions / References / ... (Trouble)";
+        };
       }
       {
         mode = "n";
         key = "<leader>xL";
         action = "<cmd>Trouble loclist toggle<cr>";
-        options = {desc = "Location List (Trouble)";};
+        options = {
+          desc = "Location List (Trouble)";
+        };
       }
       {
         mode = "n";
         key = "<leader>xQ";
         action = "<cmd>Trouble qflist toggle<cr>";
-        options = {desc = "Quickfix List (Trouble)";};
+        options = {
+          desc = "Quickfix List (Trouble)";
+        };
       }
     ];
 

--- a/modules/openssh.nix
+++ b/modules/openssh.nix
@@ -3,33 +3,35 @@
   lib,
   specialArgs,
   ...
-}: let
+}:
+let
   inherit (specialArgs) hostname username;
   cfg = config.home.openssh;
 in
-  with lib; {
-    options = {
-      home.openssh.enable = mkEnableOption "openssh";
-    };
+with lib;
+{
+  options = {
+    home.openssh.enable = mkEnableOption "openssh";
+  };
 
-    config = mkIf cfg.enable {
-      sops.secrets = {
-        "ssh/id_ed25519" = {
-          format = "binary";
-          sopsFile = ../hosts/${hostname}/users/${username}/secrets/id_ed25519;
-          path = config.home.homeDirectory + "/.ssh/id_ed25519";
-          mode = "600";
-        };
-        "ssh/id_ed25519.pub" = {
-          format = "binary";
-          sopsFile = ../hosts/${hostname}/users/${username}/secrets/id_ed25519.pub;
-          path = config.home.homeDirectory + "/.ssh/id_ed25519.pub";
-          mode = "600";
-        };
+  config = mkIf cfg.enable {
+    sops.secrets = {
+      "ssh/id_ed25519" = {
+        format = "binary";
+        sopsFile = ../hosts/${hostname}/users/${username}/secrets/id_ed25519;
+        path = config.home.homeDirectory + "/.ssh/id_ed25519";
+        mode = "600";
       };
-
-      programs.ssh = {
-        enable = true;
+      "ssh/id_ed25519.pub" = {
+        format = "binary";
+        sopsFile = ../hosts/${hostname}/users/${username}/secrets/id_ed25519.pub;
+        path = config.home.homeDirectory + "/.ssh/id_ed25519.pub";
+        mode = "600";
       };
     };
-  }
+
+    programs.ssh = {
+      enable = true;
+    };
+  };
+}

--- a/modules/rclone.nix
+++ b/modules/rclone.nix
@@ -3,81 +3,83 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.home.rclone;
 in
-  with lib; {
-    options = {
-      home.rclone.enable = mkEnableOption "rclone";
-    };
+with lib;
+{
+  options = {
+    home.rclone.enable = mkEnableOption "rclone";
+  };
 
-    config = mkIf cfg.enable {
-      home.packages = with pkgs; [
-        fuse
-        rclone
-      ];
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      fuse
+      rclone
+    ];
 
-      # TODO: encrypt to disk using rclone config encryption?
-      sops.secrets = {
-        "rclone/rclone.conf" = {
-          format = "binary";
-          sopsFile = ../hosts/shared/secrets/rclone.conf;
-          path = config.home.homeDirectory + "/.config/rclone/rclone.conf";
-          mode = "600";
-        };
-      };
-
-      systemd.user.services = {
-        gdrive = {
-          Unit = {
-            Description = "rclone: Remote FUSE filesystem for Google Drive";
-            Documentation = "man:rclone(1)";
-            After = ["network-online.target"];
-            Wants = ["network-online.target"];
-          };
-          Service = {
-            Type = "notify";
-            Environment = ["PATH=/run/wrappers/bin/:$PATH"];
-            ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/Documents/'Google Drive'";
-            ExecStart = ''
-              ${pkgs.rclone}/bin/rclone mount \
-              --config=%h/.config/rclone/rclone.conf \
-              --umask 022 \
-              --vfs-cache-mode writes \
-              gdrive: %h/Documents/'Google Drive'
-            '';
-            ExecStop = "/run/wrappers/bin/fusermount -u %h/Documents/'Google Drive'";
-          };
-          Install.WantedBy = ["default.target"];
-        };
-        gcrypt = {
-          Unit = {
-            Description = "rclone: Remote FUSE filesystem for media files";
-            Documentation = "man:rclone(1)";
-            After = ["network-online.target"];
-            Wants = ["network-online.target"];
-          };
-          Service = {
-            Type = "notify";
-            Environment = ["PATH=/run/wrappers/bin/:$PATH"];
-            ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/Documents/Media";
-            ExecStart = ''
-              ${pkgs.rclone}/bin/rclone mount \
-              --buffer-size 32M \
-              --config=%h/.config/rclone/rclone.conf \
-              --no-checksum \
-              --no-modtime \
-              --read-only \
-              --vfs-cache-mode full \
-              --vfs-fast-fingerprint \
-              --vfs-read-ahead 64M \
-              --umask 022 \
-              gcrypt: %h/Documents/Media
-            '';
-            ExecStop = "/run/wrappers/bin/fusermount -u %h/Documents/Media";
-          };
-          Install.WantedBy = ["default.target"];
-        };
+    # TODO: encrypt to disk using rclone config encryption?
+    sops.secrets = {
+      "rclone/rclone.conf" = {
+        format = "binary";
+        sopsFile = ../hosts/shared/secrets/rclone.conf;
+        path = config.home.homeDirectory + "/.config/rclone/rclone.conf";
+        mode = "600";
       };
     };
-  }
+
+    systemd.user.services = {
+      gdrive = {
+        Unit = {
+          Description = "rclone: Remote FUSE filesystem for Google Drive";
+          Documentation = "man:rclone(1)";
+          After = [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
+        };
+        Service = {
+          Type = "notify";
+          Environment = [ "PATH=/run/wrappers/bin/:$PATH" ];
+          ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/Documents/'Google Drive'";
+          ExecStart = ''
+            ${pkgs.rclone}/bin/rclone mount \
+            --config=%h/.config/rclone/rclone.conf \
+            --umask 022 \
+            --vfs-cache-mode writes \
+            gdrive: %h/Documents/'Google Drive'
+          '';
+          ExecStop = "/run/wrappers/bin/fusermount -u %h/Documents/'Google Drive'";
+        };
+        Install.WantedBy = [ "default.target" ];
+      };
+      gcrypt = {
+        Unit = {
+          Description = "rclone: Remote FUSE filesystem for media files";
+          Documentation = "man:rclone(1)";
+          After = [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
+        };
+        Service = {
+          Type = "notify";
+          Environment = [ "PATH=/run/wrappers/bin/:$PATH" ];
+          ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/Documents/Media";
+          ExecStart = ''
+            ${pkgs.rclone}/bin/rclone mount \
+            --buffer-size 32M \
+            --config=%h/.config/rclone/rclone.conf \
+            --no-checksum \
+            --no-modtime \
+            --read-only \
+            --vfs-cache-mode full \
+            --vfs-fast-fingerprint \
+            --vfs-read-ahead 64M \
+            --umask 022 \
+            gcrypt: %h/Documents/Media
+          '';
+          ExecStop = "/run/wrappers/bin/fusermount -u %h/Documents/Media";
+        };
+        Install.WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/modules/sops.nix
+++ b/modules/sops.nix
@@ -5,41 +5,43 @@
   pkgs,
   specialArgs,
   ...
-}: let
+}:
+let
   inherit (specialArgs) hostname username;
   cfg = config.home.sops;
 in
-  with lib; {
-    imports = [
-      inputs.sops-nix.homeManagerModules.sops
+with lib;
+{
+  imports = [
+    inputs.sops-nix.homeManagerModules.sops
+  ];
+
+  options = {
+    home.sops.enable = mkEnableOption "secret management using sops";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      age
+      ssh-to-age
+      sops
     ];
 
-    options = {
-      home.sops.enable = mkEnableOption "secret management using sops";
+    services.gpg-agent = {
+      enable = true;
+      enableSshSupport = true;
+      enableExtraSocket = false;
+      enableZshIntegration = config.programs.zsh.enable;
+      pinentryPackage = pkgs.pinentry-gnome3;
     };
 
-    config = mkIf cfg.enable {
-      home.packages = with pkgs; [
-        age
-        ssh-to-age
-        sops
-      ];
-
-      services.gpg-agent = {
-        enable = true;
-        enableSshSupport = true;
-        enableExtraSocket = false;
-        enableZshIntegration = config.programs.zsh.enable;
-        pinentryPackage = pkgs.pinentry-gnome3;
-      };
-
-      programs.gpg = {
-        enable = true;
-      };
-
-      sops = {
-        age.keyFile = "/home/${username}/.config/sops/age/keys.txt";
-        defaultSopsFile = ../hosts/${hostname}/secrets/secrets.yaml;
-      };
+    programs.gpg = {
+      enable = true;
     };
-  }
+
+    sops = {
+      age.keyFile = "/home/${username}/.config/sops/age/keys.txt";
+      defaultSopsFile = ../hosts/${hostname}/secrets/secrets.yaml;
+    };
+  };
+}

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -3,17 +3,19 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.home.steam;
 in
-  with lib; {
-    options = {
-      home.steam.enable = mkEnableOption "steam";
-    };
+with lib;
+{
+  options = {
+    home.steam.enable = mkEnableOption "steam";
+  };
 
-    config = mkIf cfg.enable {
-      home.packages = with pkgs; [
-        protonup
-      ];
-    };
-  }
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      protonup
+    ];
+  };
+}

--- a/modules/stylix.nix
+++ b/modules/stylix.nix
@@ -4,67 +4,69 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.home.stylix;
 in
-  with lib; {
-    imports = [
-      inputs.stylix.homeManagerModules.stylix
+with lib;
+{
+  imports = [
+    inputs.stylix.homeManagerModules.stylix
+  ];
+
+  options = {
+    home.stylix.enable = mkEnableOption "stylix";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      (nerdfonts.override {
+        fonts = [
+          "Noto"
+        ];
+      })
+      noto-fonts
+      noto-fonts-emoji
     ];
 
-    options = {
-      home.stylix.enable = mkEnableOption "stylix";
-    };
-
-    config = mkIf cfg.enable {
-      home.packages = with pkgs; [
-        (nerdfonts.override {
-          fonts = [
-            "Noto"
-          ];
-        })
-        noto-fonts
-        noto-fonts-emoji
-      ];
-
-      stylix = {
-        enable = true;
-        base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-mocha.yaml";
-        cursor = {
-          name = "Bibata-Modern-Ice";
-          package = pkgs.bibata-cursors;
-          size = 24;
+    stylix = {
+      enable = true;
+      base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-mocha.yaml";
+      cursor = {
+        name = "Bibata-Modern-Ice";
+        package = pkgs.bibata-cursors;
+        size = 24;
+      };
+      fonts = {
+        serif = {
+          name = "NotoSerif Nerd Font Propo";
+          package = pkgs.noto-fonts;
         };
-        fonts = {
-          serif = {
-            name = "NotoSerif Nerd Font Propo";
-            package = pkgs.noto-fonts;
-          };
-          sansSerif = {
-            name = "NotoSans Nerd Font Propo";
-            package = pkgs.noto-fonts;
-          };
-          monospace = {
-            name = "NotoMono Nerd Font Propo";
-            package = pkgs.noto-fonts;
-          };
-          emoji = {
-            name = "Noto Color Emoji";
-            package = pkgs.noto-fonts-emoji;
-          };
+        sansSerif = {
+          name = "NotoSans Nerd Font Propo";
+          package = pkgs.noto-fonts;
         };
-        iconTheme = {
-          enable = true;
-          package = pkgs.papirus-icon-theme;
-          dark = "Papirus Dark";
-          light = "Papirus Light";
+        monospace = {
+          name = "NotoMono Nerd Font Propo";
+          package = pkgs.noto-fonts;
         };
-        image = ../dotfiles/firewatch-green-1.jpg;
-        polarity = "dark";
-        targets = {
-          # TODO: evaluate whether I want to enable this at some point
-          hyprland.enable = false;
+        emoji = {
+          name = "Noto Color Emoji";
+          package = pkgs.noto-fonts-emoji;
         };
       };
+      iconTheme = {
+        enable = true;
+        package = pkgs.papirus-icon-theme;
+        dark = "Papirus Dark";
+        light = "Papirus Light";
+      };
+      image = ../dotfiles/firewatch-green-1.jpg;
+      polarity = "dark";
+      targets = {
+        # TODO: evaluate whether I want to enable this at some point
+        hyprland.enable = false;
+      };
     };
-  }
+  };
+}

--- a/modules/waybar.nix
+++ b/modules/waybar.nix
@@ -2,192 +2,210 @@
   config,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.home.waybar;
 in
-  with lib; {
-    options = {
-      home.waybar.enable = mkEnableOption "waybar";
+with lib;
+{
+  options = {
+    home.waybar.enable = mkEnableOption "waybar";
+  };
+
+  config = mkIf cfg.enable {
+    programs.waybar = {
+      enable = true;
+      settings = [
+        {
+          "height" = 16;
+          "layer" = "top";
+          "margin-bottom" = 0;
+          "margin-left" = 0;
+          "margin-right" = 0;
+          "margin-top" = 0;
+          "spacing" = 0;
+
+          "modules-left" = [
+            "hyprland/workspaces"
+            "hyprland/window"
+          ];
+
+          "modules-center" = [
+            "wlr/taskbar"
+          ];
+
+          "modules-right" = [
+            "idle_inhibitor"
+            "cpu"
+            "memory"
+            "pulseaudio"
+            "network"
+            "bluetooth"
+            "backlight"
+            "battery"
+            "clock"
+            "clock#date"
+            "tray"
+          ];
+
+          "hyprland/workspaces" = {
+            "on-click" = "activate";
+            "all-outputs" = false;
+            "format" = "{icon}";
+            "format-icons" = {
+              "1" = "1";
+              "2" = "2";
+              "3" = "3";
+              "4" = "4";
+              "5" = "5";
+              "6" = "6";
+              "active" = "";
+            };
+            "persistent-workspaces" = {
+              "*" = 6;
+            };
+          };
+
+          "hyprland/window" = {
+            "separate-outputs" = true;
+          };
+
+          "wlr/taskbar" = {
+            "format" = "{icon}";
+            "icon-size" = 18;
+            "tooltip-format" = "{title}";
+            "on-click" = "activate";
+            "on-click-middle" = "close";
+            "ignore-list" = [ ];
+            "app_ids-mapping" = { };
+            "rewrite" = { };
+          };
+
+          "idle_inhibitor" = {
+            "format" = "{icon}";
+            "format-icons" = {
+              "activated" = "";
+              "deactivated" = "";
+            };
+          };
+
+          "cpu" = {
+            "format" = "CPU {usage}% ";
+          };
+
+          "memory" = {
+            "format" = "RAM {}% ";
+          };
+
+          "pulseaudio" = {
+            "format" = "{icon} {volume}%  {format_source}";
+            "format-muted" = " off  {format_source}";
+            "format-source" = " on";
+            "format-source-muted" = " off";
+            "format-icons" = {
+              "headphone" = " ";
+              "hands-free" = " ";
+              "headset" = " ";
+              "phone" = "";
+              "portable" = "";
+              "car" = "";
+              "default" = [
+                ""
+                " "
+                " "
+              ];
+            };
+            "on-click" = "pavucontrol";
+          };
+
+          "network" = {
+            "format" = "{ifname}";
+            "format-wifi" = "   {signalStrength}%";
+            "format-ethernet" = "  {ipaddr}";
+            "format-disconnected" = "";
+            "tooltip-format" = " {ifname} via {gwaddri}";
+            "tooltip-format-wifi" = "   {essid} ({signalStrength}%)";
+            "tooltip-format-ethernet" = "  {ifname} ({ipaddr}/{cidr})";
+            "tooltip-format-disconnected" = "Disconnected";
+            "max-length" = 50;
+            "on-click" = "iwgtk";
+          };
+
+          "bluetooth" = {
+            "format" = " {status}";
+            "format-off" = "󰂲 off";
+            "format-disabled" = "󰂲 disabled";
+            "format-connected" = " {num_connections}";
+            "tooltip-format" = "{device_alias}";
+            "tooltip-format-connected" = "󰂰 {device_enumerate}";
+            "tooltip-format-enumerate-connected" = "{device_alias}";
+            "on-click" = "blueman-manager";
+          };
+
+          "battery" = {
+            "interval" = 1;
+            "states" = {
+              "warning" = 30;
+              "critical" = 15;
+            };
+            "format" = "{icon}  {capacity}%";
+            "format-charging" = "  {capacity}%";
+            "format-plugged" = "   {capacity}%";
+            "format-icons" = [
+              " "
+              " "
+              " "
+              " "
+              " "
+            ];
+          };
+
+          "backlight" = {
+            "device" = "intel_backlight";
+            "format" = "{icon}  {percent}%";
+            "format-icons" = [
+              "󰃛"
+              "󰃝"
+              "󰃞"
+              "󰃟"
+              "󰃠"
+            ];
+            "states" = {
+              "off" = 0;
+              "low" = 20;
+              "medium" = 60;
+              "high" = 80;
+              "full" = 100;
+            };
+          };
+
+          "clock" = {
+            "format" = "{:%H:%M:%S}";
+            "interval" = 1;
+            "tooltip" = false;
+          };
+
+          "clock#date" = {
+            "format" = "{:%d-%m-%Y}";
+            "tooltip-format" = "<tt><small>{calendar}</small></tt>";
+            "calendar" = {
+              "format" = {
+                "weekdays" = "<span color='#E0AF68'>{}</span>";
+                "months" = "<span color='#FFEAD3'>{}</span>";
+                "weeks" = "<span color='#C3E88D'>W{}</span>";
+                "today" = "<span color='#FF6699'><b>{}</b></span>";
+              };
+              "mode" = "month";
+              "weeks-pos" = "left";
+            };
+          };
+
+          "tray" = {
+            "icon-size" = 16;
+            "spacing" = 10;
+          };
+        }
+      ];
     };
-
-    config = mkIf cfg.enable {
-      programs.waybar = {
-        enable = true;
-        settings = [
-          {
-            "height" = 16;
-            "layer" = "top";
-            "margin-bottom" = 0;
-            "margin-left" = 0;
-            "margin-right" = 0;
-            "margin-top" = 0;
-            "spacing" = 0;
-
-            "modules-left" = [
-              "hyprland/workspaces"
-              "hyprland/window"
-            ];
-
-            "modules-center" = [
-              "wlr/taskbar"
-            ];
-
-            "modules-right" = [
-              "idle_inhibitor"
-              "cpu"
-              "memory"
-              "pulseaudio"
-              "network"
-              "bluetooth"
-              "backlight"
-              "battery"
-              "clock"
-              "clock#date"
-              "tray"
-            ];
-
-            "hyprland/workspaces" = {
-              "on-click" = "activate";
-              "all-outputs" = false;
-              "format" = "{icon}";
-              "format-icons" = {
-                "1" = "1";
-                "2" = "2";
-                "3" = "3";
-                "4" = "4";
-                "5" = "5";
-                "6" = "6";
-                "active" = "";
-              };
-              "persistent-workspaces" = {
-                "*" = 6;
-              };
-            };
-
-            "hyprland/window" = {
-              "separate-outputs" = true;
-            };
-
-            "wlr/taskbar" = {
-              "format" = "{icon}";
-              "icon-size" = 18;
-              "tooltip-format" = "{title}";
-              "on-click" = "activate";
-              "on-click-middle" = "close";
-              "ignore-list" = [];
-              "app_ids-mapping" = {};
-              "rewrite" = {};
-            };
-
-            "idle_inhibitor" = {
-              "format" = "{icon}";
-              "format-icons" = {
-                "activated" = "";
-                "deactivated" = "";
-              };
-            };
-
-            "cpu" = {
-              "format" = "CPU {usage}% ";
-            };
-
-            "memory" = {
-              "format" = "RAM {}% ";
-            };
-
-            "pulseaudio" = {
-              "format" = "{icon} {volume}%  {format_source}";
-              "format-muted" = " off  {format_source}";
-              "format-source" = " on";
-              "format-source-muted" = " off";
-              "format-icons" = {
-                "headphone" = " ";
-                "hands-free" = " ";
-                "headset" = " ";
-                "phone" = "";
-                "portable" = "";
-                "car" = "";
-                "default" = ["" " " " "];
-              };
-              "on-click" = "pavucontrol";
-            };
-
-            "network" = {
-              "format" = "{ifname}";
-              "format-wifi" = "   {signalStrength}%";
-              "format-ethernet" = "  {ipaddr}";
-              "format-disconnected" = "";
-              "tooltip-format" = " {ifname} via {gwaddri}";
-              "tooltip-format-wifi" = "   {essid} ({signalStrength}%)";
-              "tooltip-format-ethernet" = "  {ifname} ({ipaddr}/{cidr})";
-              "tooltip-format-disconnected" = "Disconnected";
-              "max-length" = 50;
-              "on-click" = "iwgtk";
-            };
-
-            "bluetooth" = {
-              "format" = " {status}";
-              "format-off" = "󰂲 off";
-              "format-disabled" = "󰂲 disabled";
-              "format-connected" = " {num_connections}";
-              "tooltip-format" = "{device_alias}";
-              "tooltip-format-connected" = "󰂰 {device_enumerate}";
-              "tooltip-format-enumerate-connected" = "{device_alias}";
-              "on-click" = "blueman-manager";
-            };
-
-            "battery" = {
-              "interval" = 1;
-              "states" = {
-                "warning" = 30;
-                "critical" = 15;
-              };
-              "format" = "{icon}  {capacity}%";
-              "format-charging" = "  {capacity}%";
-              "format-plugged" = "   {capacity}%";
-              "format-icons" = [" " " " " " " " " "];
-            };
-
-            "backlight" = {
-              "device" = "intel_backlight";
-              "format" = "{icon}  {percent}%";
-              "format-icons" = ["󰃛" "󰃝" "󰃞" "󰃟" "󰃠"];
-              "states" = {
-                "off" = 0;
-                "low" = 20;
-                "medium" = 60;
-                "high" = 80;
-                "full" = 100;
-              };
-            };
-
-            "clock" = {
-              "format" = "{:%H:%M:%S}";
-              "interval" = 1;
-              "tooltip" = false;
-            };
-
-            "clock#date" = {
-              "format" = "{:%d-%m-%Y}";
-              "tooltip-format" = "<tt><small>{calendar}</small></tt>";
-              "calendar" = {
-                "format" = {
-                  "weekdays" = "<span color='#E0AF68'>{}</span>";
-                  "months" = "<span color='#FFEAD3'>{}</span>";
-                  "weeks" = "<span color='#C3E88D'>W{}</span>";
-                  "today" = "<span color='#FF6699'><b>{}</b></span>";
-                };
-                "mode" = "month";
-                "weeks-pos" = "left";
-              };
-            };
-
-            "tray" = {
-              "icon-size" = 16;
-              "spacing" = 10;
-            };
-          }
-        ];
-      };
-    };
-  }
+  };
+}

--- a/modules/yazi.nix
+++ b/modules/yazi.nix
@@ -3,19 +3,21 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   cfg = config.home.yazi;
 in
-  with lib; {
-    options = {
-      home.yazi.enable = mkEnableOption "yazi";
-    };
+with lib;
+{
+  options = {
+    home.yazi.enable = mkEnableOption "yazi";
+  };
 
-    config = mkIf cfg.enable {
-      home.packages = with pkgs; [
-        ueberzugpp
-      ];
+  config = mkIf cfg.enable {
+    home.packages = with pkgs; [
+      ueberzugpp
+    ];
 
-      programs.yazi.enable = true;
-    };
-  }
+    programs.yazi.enable = true;
+  };
+}

--- a/modules/zellij.nix
+++ b/modules/zellij.nix
@@ -2,52 +2,88 @@
   config,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.home.zellij;
 in
-  with lib; {
-    options = {
-      home.zellij.enable = mkEnableOption "zellij";
-    };
+with lib;
+{
+  options = {
+    home.zellij.enable = mkEnableOption "zellij";
+  };
 
-    config = mkIf cfg.enable {
-      programs = {
-        # TODO: toggle this based on whether or not alacritty was enabled?
-        alacritty = {
-          settings = {
-            terminal.shell = "zellij";
-          };
+  config = mkIf cfg.enable {
+    programs = {
+      # TODO: toggle this based on whether or not alacritty was enabled?
+      alacritty = {
+        settings = {
+          terminal.shell = "zellij";
         };
-        zellij = {
-          enable = true;
-          settings = {
-            default_layout = "compact";
-            # NOTE: https://github.com/zellij-org/zellij/blob/main/zellij-utils/assets/config/default.kdl
-            keybinds = {
-              "normal clear-defaults=true" = {
-                "bind \"Ctrl b\"" = {"SwitchToMode" = "Tmux";};
+      };
+      zellij = {
+        enable = true;
+        settings = {
+          default_layout = "compact";
+          # NOTE: https://github.com/zellij-org/zellij/blob/main/zellij-utils/assets/config/default.kdl
+          keybinds = {
+            "normal clear-defaults=true" = {
+              "bind \"Ctrl b\"" = {
+                "SwitchToMode" = "Tmux";
               };
-              tmux = {
-                "bind \"Ctrl b\"" = {"Write 2; SwitchToMode" = "Normal";};
-                "bind \"Esc\"" = {"SwitchToMode" = "Normal";};
-                "bind \"l\"" = {"SwitchToMode" = "Locked";};
-                "bind \"p\"" = {"SwitchToMode" = "Pane";};
-                "bind \"t\"" = {"SwitchToMode" = "Tab";};
-                "bind \"r\"" = {"SwitchToMode" = "Resize";};
-                "bind \"m\"" = {"SwitchToMode" = "Move";};
-                "bind \"s\"" = {"SwitchToMode" = "Scroll";};
-                "bind \"o\"" = {"SwitchToMode" = "Session";};
-                "bind \"q\"" = {Quit = {};};
-                "bind \"Alt h\"" = {"MoveFocusOrTab" = "Left";};
-                "bind \"Alt l\"" = {"MoveFocusOrTab" = "Right";};
-                "bind \"Alt j\"" = {"MoveFocus" = "Down";};
-                "bind \"Alt k\"" = {"MoveFocus" = "Up";};
-                "bind \"Alt =\"" = {"Resize" = "Increase";};
-                "bind \"Alt -\"" = {"Resize" = "Decrease";};
+            };
+            tmux = {
+              "bind \"Ctrl b\"" = {
+                "Write 2; SwitchToMode" = "Normal";
+              };
+              "bind \"Esc\"" = {
+                "SwitchToMode" = "Normal";
+              };
+              "bind \"l\"" = {
+                "SwitchToMode" = "Locked";
+              };
+              "bind \"p\"" = {
+                "SwitchToMode" = "Pane";
+              };
+              "bind \"t\"" = {
+                "SwitchToMode" = "Tab";
+              };
+              "bind \"r\"" = {
+                "SwitchToMode" = "Resize";
+              };
+              "bind \"m\"" = {
+                "SwitchToMode" = "Move";
+              };
+              "bind \"s\"" = {
+                "SwitchToMode" = "Scroll";
+              };
+              "bind \"o\"" = {
+                "SwitchToMode" = "Session";
+              };
+              "bind \"q\"" = {
+                Quit = { };
+              };
+              "bind \"Alt h\"" = {
+                "MoveFocusOrTab" = "Left";
+              };
+              "bind \"Alt l\"" = {
+                "MoveFocusOrTab" = "Right";
+              };
+              "bind \"Alt j\"" = {
+                "MoveFocus" = "Down";
+              };
+              "bind \"Alt k\"" = {
+                "MoveFocus" = "Up";
+              };
+              "bind \"Alt =\"" = {
+                "Resize" = "Increase";
+              };
+              "bind \"Alt -\"" = {
+                "Resize" = "Decrease";
               };
             };
           };
         };
       };
     };
-  }
+  };
+}

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -48,7 +48,7 @@ with lib;
             "history"
             "laravel"
             "rails"
-            "gpg-agent"
+            "ssh-agent"
           ];
         };
         shellAliases = {

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -2,79 +2,82 @@
   config,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.home.zsh;
 in
-  with lib; {
-    options = {
-      home.zsh.enable = mkEnableOption "zsh";
-    };
+with lib;
+{
+  options = {
+    home.zsh.enable = mkEnableOption "zsh";
+  };
 
-    config = mkIf cfg.enable {
-      programs = {
-        direnv = mkIf config.programs.direnv.enable {
-          enableZshIntegration = true;
-        };
-        fastfetch.enable = true;
-        yazi = mkIf config.programs.yazi.enable {
-          enableZshIntegration = true;
-        };
-        zoxide = {
+  config = mkIf cfg.enable {
+    programs = {
+      direnv = mkIf config.programs.direnv.enable {
+        enableZshIntegration = true;
+        nix-direnv.enable = true;
+      };
+      fastfetch.enable = true;
+      yazi = mkIf config.programs.yazi.enable {
+        enableZshIntegration = true;
+      };
+      zoxide = {
+        enable = true;
+        options = [
+          "--cmd cd"
+        ];
+      };
+      zsh = {
+        enable = true;
+        enableCompletion = true; # NOTE: add environment.pathsToLink = [ "/share/zsh" ]; to system when running NixOS
+        autosuggestion.enable = true;
+        history.ignoreAllDups = true;
+        historySubstringSearch.enable = true;
+        oh-my-zsh = {
           enable = true;
-          options = [
-            "--cmd cd"
+          theme = "juanghurtado";
+          plugins = [
+            "asdf"
+            "colorize"
+            "colored-man-pages"
+            "composer"
+            "docker"
+            "docker-compose"
+            "git"
+            "history"
+            "laravel"
+            "rails"
+            "gpg-agent"
           ];
         };
-        zsh = {
-          enable = true;
-          enableCompletion = true; # NOTE: add environment.pathsToLink = [ "/share/zsh" ]; to system when running NixOS
-          autosuggestion.enable = true;
-          history.ignoreAllDups = true;
-          historySubstringSearch.enable = true;
-          oh-my-zsh = {
-            enable = true;
-            theme = "juanghurtado";
-            plugins = [
-              "asdf"
-              "colorize"
-              "colored-man-pages"
-              "composer"
-              "docker"
-              "docker-compose"
-              "git"
-              "history"
-              "laravel"
-              "rails"
-              "gpg-agent"
-            ];
-          };
-          shellAliases = {
-            a = "artisan";
-            tinker = "artisan tinker";
-            cat = "bat --paging=never";
-            gl = "git sla";
-            gfix = "git fix";
-            kamal = "docker run -it --rm -v '$PWD:/workdir' -v '$SSH_AUTH_SOCK:/ssh-agent' -v /var/run/docker.sock:/var/run/docker.sock -e 'SSH_AUTH_SOCK=/ssh-agent' ghcr.io/basecamp/kamal:latest";
-          };
-          initExtra = ''
-            # automatically prune branches both local and remote
-            function gpb {
-              git checkout "$(git_main_branch)"
-              git fetch
-              git remote prune origin
-              git branch --merged | grep -vE "$(git_main_branch)|$(git_develop_branch)" | xargs -r git branch -d
-            }
-
-            # git remove submodule
-            function grms {
-              git rm $PWD/$1
-              rm -rf $PWD/.git/modules/$1
-              git config --remove-section submodule.$1
-            }
-
-            fastfetch
-          '';
+        shellAliases = {
+          a = "artisan";
+          tinker = "artisan tinker";
+          cat = "bat --paging=never";
+          gl = "git sla";
+          gfix = "git fix";
+          kamal = "docker run -it --rm -v '$PWD:/workdir' -v '$SSH_AUTH_SOCK:/ssh-agent' -v /var/run/docker.sock:/var/run/docker.sock -e 'SSH_AUTH_SOCK=/ssh-agent' ghcr.io/basecamp/kamal:latest";
         };
+        initExtra = ''
+          # automatically prune branches both local and remote
+          function gpb {
+            git checkout "$(git_main_branch)"
+            git fetch
+            git remote prune origin
+            git branch --merged | grep -vE "$(git_main_branch)|$(git_develop_branch)" | xargs -r git branch -d
+          }
+
+          # git remove submodule
+          function grms {
+            git rm $PWD/$1
+            rm -rf $PWD/.git/modules/$1
+            git config --remove-section submodule.$1
+          }
+
+          fastfetch
+        '';
       };
     };
-  }
+  };
+}


### PR DESCRIPTION
 - [x] Format `.nix` files using the `nixfmt-rfc-style` formatter which is scheduled to become the official formatter.
 - [x] Use dedicated formatters for `.css`, `.json`, `.md` with `eslint_d` fallback.