### PR TITLE
Enable nix-direnv home-manager integration

### DIFF
--- a/hosts/luna/users/shorty/default.nix
+++ b/hosts/luna/users/shorty/default.nix
@@ -55,7 +55,10 @@ with lib;
     bat.enable = true;
     btop.enable = true;
     chromium.enable = true;
-    direnv.enable = true;
+    direnv = {
+      enable = true;
+      nix-direnv.enable = true;
+    };
     # eza.enable = true; # rust based ls replacement
     feh.enable = true; # image viewer
     obs-studio.enable = true;

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -16,7 +16,6 @@ with lib;
     programs = {
       direnv = mkIf config.programs.direnv.enable {
         enableZshIntegration = true;
-        nix-direnv.enable = true;
       };
       fastfetch.enable = true;
       yazi = mkIf config.programs.yazi.enable {


### PR DESCRIPTION
Turned out `direnv` was pretty much working already. Since we are using Nix Flakes shell configuration is declared inside the `flake.nix` file and `devShells.${system}` attribute set.

Might be a good time to look into declaring my configuration for every supported system and maybe take a look at [treefmt](https://github.com/numtide/treefmt-nix?tab=readme-ov-file). Not entirely sure how nicely that will integrate with nixvim formatters.